### PR TITLE
Added quick command to add tasks as if they were entered in the todoist UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ filter_parser.go
 y.output
 
 _vendor-*
+vendor

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -94,6 +94,16 @@ func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 	return c.doApi(ctx, http.MethodPost, "sync", commands.UrlValues(), &r)
 }
 
+func (c *Client) QuickCommand(ctx context.Context, text string) error {
+	var r ExecResult
+
+	values := url.Values{
+		"text": {text},
+	}
+
+	return c.doApi(ctx, http.MethodPost, "quick/add", values, &r)
+}
+
 func (c *Client) Sync(ctx context.Context) error {
 	params := url.Values{"sync_token": {"*"}, "resource_types": {"[\"all\"]"}}
 

--- a/main.go
+++ b/main.go
@@ -230,6 +230,12 @@ func main() {
 			Usage:   "Sync cache",
 			Action:  Sync,
 		},
+		{
+			Name:    "quick",
+			Aliases: []string{"q"},
+			Usage:   "Quick add a task",
+			Action:  Quick,
+		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)

--- a/quick.go
+++ b/quick.go
@@ -14,5 +14,6 @@ func Quick(c *cli.Context) error {
 	}
 
 	client.QuickCommand(context.Background(), c.Args().First())
-	return nil
+
+	return Sync(c)
 }

--- a/quick.go
+++ b/quick.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+
+	"github.com/urfave/cli"
+)
+
+func Quick(c *cli.Context) error {
+	client := GetClient(c)
+
+	if !c.Args().Present() {
+		return CommandFailed
+	}
+
+	client.QuickCommand(context.Background(), c.Args().First())
+	return nil
+}


### PR DESCRIPTION
Todoist has a way to allow the user to send a string and have it parsed similar to how it would be in the UI. This adds a command to the cli for it.