### PR TITLE
Standardize verb tense in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ VERSION:
    0.10.1
 
 COMMANDS:
-     list, l                  Shows all tasks
+     list, l                  Show all tasks
      show                     Show task detail
-     completed-list, c-l, cl  Shows all completed tasks (only premium user)
+     completed-list, c-l, cl  Show all completed tasks (only premium users)
      add, a                   Add task
      modify, m                Modify task
      close, c                 Close task
      delete, d                Delete task
-     labels                   Shows all labels
-     projects                 Shows all projects
+     labels                   Show all labels
+     projects                 Show all projects
      karma                    Show karma
      sync, s                  Sync cache
      quick, q                 Quick add a task
-     help, h                  Shows a list of commands or help for one command
+     help, h                  Show a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --color              colorize output
@@ -61,7 +61,7 @@ GLOBAL OPTIONS:
 
 ### `list --filter`
 
-You can filter tasks by `--filter` option on `list` subcommand.  
+You can filter tasks by `--filter` option on `list` subcommand.
 The filter syntax is base on [todoist official filter syntax](https://support.todoist.com/hc/en-us/articles/205248842-Filters).
 
 Supported filter is [here](https://github.com/sachaos/todoist/issues/15#issuecomment-334140101).

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 	}
 	reminderFlg := cli.BoolFlag{
 		Name:  "reminder, r",
-		Usage: "set reminder (only premium user)",
+		Usage: "set reminder (only premium users)",
 	}
 
 	app.Flags = []cli.Flag{
@@ -161,7 +161,7 @@ func main() {
 		{
 			Name:    "list",
 			Aliases: []string{"l"},
-			Usage:   "Shows all tasks",
+			Usage:   "Show all tasks",
 			Action:  List,
 			Flags: []cli.Flag{
 				filterFlag,
@@ -178,7 +178,7 @@ func main() {
 		{
 			Name:    "completed-list",
 			Aliases: []string{"c-l", "cl"},
-			Usage:   "Shows all completed tasks (only premium user)",
+			Usage:   "Show all completed tasks (only premium user)",
 			Action:  CompletedList,
 			Flags: []cli.Flag{
 				filterFlag,
@@ -226,12 +226,12 @@ func main() {
 		},
 		{
 			Name:   "labels",
-			Usage:  "Shows all labels",
+			Usage:  "Show all labels",
 			Action: Labels,
 		},
 		{
 			Name:   "projects",
-			Usage:  "Shows all projects",
+			Usage:  "Show all projects",
 			Action: Projects,
 		},
 		{


### PR DESCRIPTION
I thought it would be a little cleaner if the verb tense were standardized in the imperative. Right now it's a mix of imperative and... descriptive (forget what that tense is called).