### PR TITLE
Fix broken due dates

### DIFF
--- a/filter_eval_test.go
+++ b/filter_eval_test.go
@@ -10,6 +10,10 @@ import (
 
 var testTimeZone = time.FixedZone("JST", 9*60*60)
 
+func ptrTo(s string) *string {
+	return &s
+}
+
 func testFilterEval(t *testing.T, f string, item todoist.Item, expect bool) {
 	actual, _ := Eval(Filter(f), item, todoist.Projects{}, todoist.Labels{})
 	assert.Equal(t, expect, actual, "they should be equal")
@@ -102,60 +106,60 @@ func TestDueOnEval(t *testing.T) {
 	timeNow := time.Date(2017, time.October, 2, 1, 0, 0, 0, testTimeZone) // JST: Mon 2 Oct 2017 00:00:00
 	setNow(timeNow)
 
-	testFilterEval(t, "today", todoist.Item{DueDateUtc: "Sun 1 Oct 2017 15:00:00 +0000"}, true)  // JST: Mon 2 Oct 2017 00:00:00
-	testFilterEval(t, "today", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 14:59:59 +0000"}, true)  // JST: Mon 2 Oct 2017 23:59:59
-	testFilterEval(t, "today", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 15:00:00 +0000"}, false) // JST: Tue 3 Oct 2017 00:00:00
+	testFilterEval(t, "today", todoist.Item{DueDateUtc: ptrTo("Sun 1 Oct 2017 15:00:00 +0000")}, true)  // JST: Mon 2 Oct 2017 00:00:00
+	testFilterEval(t, "today", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 14:59:59 +0000")}, true)  // JST: Mon 2 Oct 2017 23:59:59
+	testFilterEval(t, "today", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 15:00:00 +0000")}, false) // JST: Tue 3 Oct 2017 00:00:00
 
-	testFilterEval(t, "yesterday", todoist.Item{DueDateUtc: "Sun 1 Oct 2017 14:59:59 +0000"}, true)   // JST: Sun 1 Oct 2017 23:59:59
-	testFilterEval(t, "yesterday", todoist.Item{DueDateUtc: "Sat 30 Sep 2017 15:00:00 +0000"}, true)  // JST: Sun 1 Oct 2017 00:00:00
-	testFilterEval(t, "yesterday", todoist.Item{DueDateUtc: "Sat 30 Sep 2017 14:59:59 +0000"}, false) // JST: Sat 30 Sept 2017 23:59:59
-	testFilterEval(t, "tomorrow", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 15:00:00 +0000"}, true)    // JST: Tue 3 Oct 2017 00:00:00
-	testFilterEval(t, "tomorrow", todoist.Item{DueDateUtc: "Tue 3 Oct 2017 14:59:59 +0000"}, true)    // JST: Tue 3 Oct 2017 23:59:59
-	testFilterEval(t, "tomorrow", todoist.Item{DueDateUtc: "Tue 3 Oct 2017 15:00:00 +0000"}, false)   // JST: Wed 4 Oct 2017 00:00:00
+	testFilterEval(t, "yesterday", todoist.Item{DueDateUtc: ptrTo("Sun 1 Oct 2017 14:59:59 +0000")}, true)   // JST: Sun 1 Oct 2017 23:59:59
+	testFilterEval(t, "yesterday", todoist.Item{DueDateUtc: ptrTo("Sat 30 Sep 2017 15:00:00 +0000")}, true)  // JST: Sun 1 Oct 2017 00:00:00
+	testFilterEval(t, "yesterday", todoist.Item{DueDateUtc: ptrTo("Sat 30 Sep 2017 14:59:59 +0000")}, false) // JST: Sat 30 Sept 2017 23:59:59
+	testFilterEval(t, "tomorrow", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 15:00:00 +0000")}, true)    // JST: Tue 3 Oct 2017 00:00:00
+	testFilterEval(t, "tomorrow", todoist.Item{DueDateUtc: ptrTo("Tue 3 Oct 2017 14:59:59 +0000")}, true)    // JST: Tue 3 Oct 2017 23:59:59
+	testFilterEval(t, "tomorrow", todoist.Item{DueDateUtc: ptrTo("Tue 3 Oct 2017 15:00:00 +0000")}, false)   // JST: Wed 4 Oct 2017 00:00:00
 
-	testFilterEval(t, "10/2/2017", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 01:00:00 +0000"}, true)        // JST: Mon 2 Oct 2017 10:00:00
-	testFilterEval(t, "10/2/2017 10:00", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 01:00:00 +0000"}, false) // JST: Mon 2 Oct 2017 10:00:00
+	testFilterEval(t, "10/2/2017", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 01:00:00 +0000")}, true)        // JST: Mon 2 Oct 2017 10:00:00
+	testFilterEval(t, "10/2/2017 10:00", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 01:00:00 +0000")}, false) // JST: Mon 2 Oct 2017 10:00:00
 }
 
 func TestNoDateEval(t *testing.T) {
-	testFilterEval(t, "no date", todoist.Item{DueDateUtc: ""}, true)
-	testFilterEval(t, "no due date", todoist.Item{DueDateUtc: ""}, true)
+	testFilterEval(t, "no date", todoist.Item{DueDateUtc: nil}, true)
+	testFilterEval(t, "no due date", todoist.Item{DueDateUtc: nil}, true)
 
-	testFilterEval(t, "no date", todoist.Item{DueDateUtc: "Sun 1 Oct 2017 15:00:00 +0000"}, false) // JST: Mon 2 Oct 2017 00:00:00
+	testFilterEval(t, "no date", todoist.Item{DueDateUtc: ptrTo("Sun 1 Oct 2017 15:00:00 +0000")}, false) // JST: Mon 2 Oct 2017 00:00:00
 }
 
 func TestDueBeforeEval(t *testing.T) {
 	timeNow := time.Date(2017, time.October, 2, 1, 0, 0, 0, testTimeZone) // JST: Mon 2 Oct 2017 00:00:00
 	setNow(timeNow)
 
-	testFilterEval(t, "due before: 10/2/2017", todoist.Item{DueDateUtc: "Sun 1 Oct 2017 15:00:00 +0000"}, false)      // JST: Mon 2 Oct 2017 00:00:00
-	testFilterEval(t, "due before: 10/2/2017", todoist.Item{DueDateUtc: "Sun 1 Oct 2017 14:59:59 +0000"}, true)       // JST: Sun 1 Oct 2017 23:59:59
-	testFilterEval(t, "due before: 10/2/2017 13:00", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 4:00:00 +0000"}, false) // JST: Mon 2 Oct 2017 13:00:00
-	testFilterEval(t, "due before: 10/2/2017 13:00", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 3:59:00 +0000"}, true)  // JST: Mon 2 Oct 2017 12:59:00
+	testFilterEval(t, "due before: 10/2/2017", todoist.Item{DueDateUtc: ptrTo("Sun 1 Oct 2017 15:00:00 +0000")}, false)      // JST: Mon 2 Oct 2017 00:00:00
+	testFilterEval(t, "due before: 10/2/2017", todoist.Item{DueDateUtc: ptrTo("Sun 1 Oct 2017 14:59:59 +0000")}, true)       // JST: Sun 1 Oct 2017 23:59:59
+	testFilterEval(t, "due before: 10/2/2017 13:00", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 4:00:00 +0000")}, false) // JST: Mon 2 Oct 2017 13:00:00
+	testFilterEval(t, "due before: 10/2/2017 13:00", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 3:59:00 +0000")}, true)  // JST: Mon 2 Oct 2017 12:59:00
 
-	testFilterEval(t, "due before: 10/2/2017 13:00", todoist.Item{DueDateUtc: ""}, false) // JST: Mon 2 Oct 2017 12:59:00
+	testFilterEval(t, "due before: 10/2/2017 13:00", todoist.Item{DueDateUtc: nil}, false) // JST: Mon 2 Oct 2017 12:59:00
 }
 
 func TestOverDueEval(t *testing.T) {
 	timeNow := time.Date(2017, time.October, 2, 12, 0, 0, 0, testTimeZone) // JST: Mon 2 Oct 2017 12:00:00
 	setNow(timeNow)
 
-	testFilterEval(t, "over due", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 2:59:00 +0000"}, true)  // JST: Mon 2 Oct 2017 11:59:00
-	testFilterEval(t, "over due", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 3:00:00 +0000"}, false) // JST: Mon 2 Oct 2017 12:00:00
-	testFilterEval(t, "od", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 2:59:00 +0000"}, true)        // JST: Mon 2 Oct 2017 11:59:00
-	testFilterEval(t, "od", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 3:00:00 +0000"}, false)       // JST: Mon 2 Oct 2017 12:00:00
+	testFilterEval(t, "over due", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 2:59:00 +0000")}, true)  // JST: Mon 2 Oct 2017 11:59:00
+	testFilterEval(t, "over due", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 3:00:00 +0000")}, false) // JST: Mon 2 Oct 2017 12:00:00
+	testFilterEval(t, "od", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 2:59:00 +0000")}, true)        // JST: Mon 2 Oct 2017 11:59:00
+	testFilterEval(t, "od", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 3:00:00 +0000")}, false)       // JST: Mon 2 Oct 2017 12:00:00
 
-	testFilterEval(t, "od", todoist.Item{DueDateUtc: ""}, false) // JST: Mon 2 Oct 2017 12:00:00
+	testFilterEval(t, "od", todoist.Item{DueDateUtc: nil}, false) // JST: Mon 2 Oct 2017 12:00:00
 }
 
 func TestDueAfterEval(t *testing.T) {
 	timeNow := time.Date(2017, time.October, 2, 1, 0, 0, 0, testTimeZone) // JST: Mon 2 Oct 2017 00:00:00
 	setNow(timeNow)
 
-	testFilterEval(t, "due after: 10/2/2017", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 14:59:59 +0000"}, false)      // JST: Mon 2 Oct 2017 23:59:59
-	testFilterEval(t, "due after: 10/2/2017", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 15:00:00 +0000"}, true)       // JST: Tue 3 Oct 2017 00:00:00
-	testFilterEval(t, "due after: 10/2/2017 13:00", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 4:00:00 +0000"}, false) // JST: Mon 2 Oct 2017 13:00:00
-	testFilterEval(t, "due after: 10/2/2017 13:00", todoist.Item{DueDateUtc: "Mon 2 Oct 2017 4:01:00 +0000"}, true)  // JST: Mon 2 Oct 2017 13:01:00
+	testFilterEval(t, "due after: 10/2/2017", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 14:59:59 +0000")}, false)      // JST: Mon 2 Oct 2017 23:59:59
+	testFilterEval(t, "due after: 10/2/2017", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 15:00:00 +0000")}, true)       // JST: Tue 3 Oct 2017 00:00:00
+	testFilterEval(t, "due after: 10/2/2017 13:00", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 4:00:00 +0000")}, false) // JST: Mon 2 Oct 2017 13:00:00
+	testFilterEval(t, "due after: 10/2/2017 13:00", todoist.Item{DueDateUtc: ptrTo("Mon 2 Oct 2017 4:01:00 +0000")}, true)  // JST: Mon 2 Oct 2017 13:01:00
 
-	testFilterEval(t, "due after: 10/2/2017 13:00", todoist.Item{DueDateUtc: ""}, false) // JST: Mon 2 Oct 2017 13:01:00
+	testFilterEval(t, "due after: 10/2/2017 13:00", todoist.Item{DueDateUtc: nil}, false) // JST: Mon 2 Oct 2017 13:01:00
 }

--- a/lib/item.go
+++ b/lib/item.go
@@ -57,7 +57,7 @@ type Item struct {
 	DateLang       string      `json:"date_lang"`
 	DateString     string      `json:"date_string"`
 	DayOrder       int         `json:"day_order"`
-	DueDateUtc     string      `json:"due_date_utc"`
+	DueDateUtc     *string     `json:"due_date_utc"`
 	HasMoreNotes   bool        `json:"has_more_notes"`
 	InHistory      int         `json:"in_history"`
 	IsArchived     int         `json:"is_archived"`
@@ -79,7 +79,15 @@ func (a Items) Less(i, j int) bool { return a[i].ID < a[j].ID }
 func (a Items) At(i int) IDCarrier { return a[i] }
 
 func (item Item) DateTime() time.Time {
-	t, _ := time.Parse(DateFormat, item.DueDateUtc)
+	var date string
+
+	if item.DueDateUtc == nil {
+		date = ""
+	} else {
+		date = *item.DueDateUtc
+	}
+
+	t, _ := time.Parse(DateFormat, date)
 	return t
 }
 


### PR DESCRIPTION
The root cause of the bug is that Todoist returns `null` for the `due_date_utc`
field when no due date is set. Go's json decoder simply ignores null values,
so the DueDateUtc field wasn't being set correctly.

It was fixed by making DueDateUtc a string pointer. Go's json decoder does set
a string pointer to `nil` if the json value is `null`.

This should fix #68.