### PR TITLE
Add "today" command; Add-P flag to the list command

### DIFF
--- a/list.go
+++ b/list.go
@@ -27,6 +27,11 @@ func List(c *cli.Context) error {
 		if !r || item.Checked == 1 {
 			continue
 		}
+
+		projectID := c.Int("project-id")
+		if projectID != 0 && item.ProjectID != projectID {
+			continue
+		}
 		itemList = append(itemList, []string{
 			IdFormat(item),
 			PriorityFormat(item.Priority),

--- a/main.go
+++ b/main.go
@@ -163,6 +163,14 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
+			Name:    "today",
+			Aliases: []string{"t"},
+			Usage:   "Show today's tasks",
+			Action:  TodayList,
+			Flags: []cli.Flag{
+			},
+		},
+		{
 			Name:    "list",
 			Aliases: []string{"l"},
 			Usage:   "Show all tasks",

--- a/main.go
+++ b/main.go
@@ -177,6 +177,7 @@ func main() {
 			Action:  List,
 			Flags: []cli.Flag{
 				filterFlag,
+				projectIDFlag,
 			},
 		},
 		{

--- a/today.go
+++ b/today.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/sachaos/todoist/lib"
+	"github.com/urfave/cli"
+)
+
+func TodayList(c *cli.Context) error {
+	client := GetClient(c)
+
+	colorList := ColorList()
+	projectsCount := len(client.Store.Projects)
+	projectIds := make([]int, projectsCount, projectsCount)
+	for i, project := range client.Store.Projects {
+		projectIds[i] = project.GetID()
+	}
+	projectColorHash := GenerateColorHash(projectIds, colorList)
+	ex := Filter("Today")
+
+	itemList := make([][]string, 0, len(client.Store.ItemOrders))
+	for _, itemOrder := range client.Store.ItemOrders {
+		item := itemOrder.Data.(todoist.Item)
+		r, err := Eval(ex, item, client.Store.Projects, client.Store.Labels)
+		if err != nil {
+			return err
+		}
+		if !r || item.Checked == 1 {
+			continue
+		}
+		itemList = append(itemList, []string{
+			IdFormat(item),
+			PriorityFormat(item.Priority),
+			DueDateFormat(item.DateTime(), item.AllDay),
+			ProjectFormat(item.ProjectID, client.Store.Projects, projectColorHash, c),
+			item.LabelsString(client.Store.Labels),
+			ContentPrefix(client.Store.Items, item, c) + ContentFormat(item),
+		})
+	}
+
+	defer writer.Flush()
+
+	if c.GlobalBool("header") {
+		writer.Write([]string{"ID", "Priority", "DueDate", "Project", "Labels", "Content"})
+	}
+
+	for _, strings := range itemList {
+		writer.Write(strings)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Firstly, thank you for this client! Really useful and can't wait to see it
evolve.

1. Today command
Using the filter (`-f`) to get the list of today's items works, but it is
a bit time consuming to type it out every time. While creating an alias
for this is easy, I would like to see it as a default command on this
cli.

2.` -P` flag for list command
I am not sure why `"-P"` flag isn't implemented for the list command, while it is available for the `modify `and `add `commands. If this isn't a design decision, here is a patch!

If these features have a chance of being merged, please respond with some
feedback. I will accommodate suggestions and write test cases to make it
a whole!