### PR TITLE
 Correctly show colorized output on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 
 	"encoding/csv"
 	"encoding/json"
@@ -155,8 +156,10 @@ func main() {
 
 		if c.Bool("csv") {
 			writer = csv.NewWriter(os.Stdout)
+		} else if runtime.GOOS == "windows" && !color.NoColor {
+				writer = NewTSVWriter(color.Output)
 		} else {
-			writer = NewTSVWriter(os.Stdout)
+				writer = NewTSVWriter(os.Stdout)
 		}
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -157,9 +157,9 @@ func main() {
 		if c.Bool("csv") {
 			writer = csv.NewWriter(os.Stdout)
 		} else if runtime.GOOS == "windows" && !color.NoColor {
-				writer = NewTSVWriter(color.Output)
+			writer = NewTSVWriter(color.Output)
 		} else {
-				writer = NewTSVWriter(os.Stdout)
+			writer = NewTSVWriter(os.Stdout)
 		}
 		return nil
 	}


### PR DESCRIPTION
Currently, colorized output is not working correctly on Windows. This change uses `runtime.GOOS` to detect the OS type and switch the output to `color.Output` for Windows (if `--color` is specified).