### PR TITLE
Fix typo in due date JSON

### DIFF
--- a/lib/item.go
+++ b/lib/item.go
@@ -21,7 +21,7 @@ type Due struct {
 	TimeZone    string `json:"timezone"`
 	IsRecurring bool   `json:"is_recurring"`
 	String      string `json:"string"`
-	Lang        string `json:"en"`
+	Lang        string `json:"lang"`
 }
 
 type BaseItem struct {


### PR DESCRIPTION
Due date syncing was broken due to a typo.