### PR TITLE
Remove no longer existing `all_day` JSON field

### DIFF
--- a/completed.go
+++ b/completed.go
@@ -39,9 +39,10 @@ func CompletedList(c *cli.Context) error {
 		if !r == true {
 			continue
 		}
+		date, _ := item.DateTime()
 		writer.Write([]string{
 			IdFormat(item),
-			CompletedDateFormat(item.DateTime()),
+			CompletedDateFormat(date),
 			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c),
 			ContentFormat(item),
 		})

--- a/filter_eval.go
+++ b/filter_eval.go
@@ -43,7 +43,8 @@ func Eval(e Expression, item todoist.AbstractItem, projects todoist.Projects, la
 		}
 	case DateExpr:
 		e := e.(DateExpr)
-		return EvalDate(e, item.DateTime()), err
+		dateTime, allDay := item.DateTime()
+		return EvalDate(e, dateTime, allDay), err
 	case NotOpExpr:
 		e := e.(NotOpExpr)
 		r, err := Eval(e.expr, item, projects, labels)
@@ -57,14 +58,13 @@ func Eval(e Expression, item todoist.AbstractItem, projects todoist.Projects, la
 	return
 }
 
-func EvalDate(e DateExpr, itemDate time.Time) (result bool) {
+func EvalDate(e DateExpr, itemDate time.Time, allDay bool) (result bool) {
 	if (itemDate == time.Time{}) {
 		if e.operation == NO_DUE_DATE {
 			return true
 		}
 		return false
 	}
-	allDay := e.allDay
 	dueDate := e.datetime
 	switch e.operation {
 	case DUE_ON:

--- a/lib/item.go
+++ b/lib/item.go
@@ -42,9 +42,9 @@ type CompletedItem struct {
 	TaskID        int         `json:"task_id"`
 }
 
-func (item CompletedItem) DateTime() time.Time {
+func (item CompletedItem) DateTime() (time.Time, bool) {
 	t, _ := time.Parse(time.RFC3339, item.CompletedData)
-	return t
+	return t, true
 }
 
 func (item CompletedItem) GetProjectID() int {
@@ -63,7 +63,6 @@ type Item struct {
 	HaveIndent
 	ChildItem      *Item       `json:"-"`
 	BrotherItem    *Item       `json:"-"`
-	AllDay         bool        `json:"all_day"`
 	AssignedByUID  int         `json:"assigned_by_uid"`
 	Checked        int         `json:"checked"`
 	Collapsed      int         `json:"collapsed"`
@@ -92,8 +91,9 @@ func (a Items) Less(i, j int) bool { return a[i].ID < a[j].ID }
 
 func (a Items) At(i int) IDCarrier { return a[i] }
 
-func (item Item) DateTime() time.Time {
+func (item Item) DateTime() (time.Time, bool) {
 	var date string
+	var allDay bool
 
 	if item.Due == nil {
 		date = ""
@@ -102,10 +102,13 @@ func (item Item) DateTime() time.Time {
 	}
 
 	t, err := time.ParseInLocation(RFC3339DateTime, date, time.Local)
+	allDay = false
+
 	if err != nil {
 		t, _ = time.ParseInLocation(RFC3339Date, date, time.Local)
+		allDay = true
 	}
-	return t
+	return t, allDay
 }
 
 func (item Item) GetProjectID() int {
@@ -118,7 +121,7 @@ func (item Item) GetLabelIDs() []int {
 
 // interface for Eval actions
 type AbstractItem interface {
-	DateTime() time.Time
+	DateTime() (time.Time, bool)
 	GetProjectID() int
 	GetLabelIDs() []int
 }

--- a/list.go
+++ b/list.go
@@ -47,10 +47,11 @@ func List(c *cli.Context) error {
 		if !r || item.Checked == 1 {
 			return
 		}
+		dateTime, allDay := item.DateTime()
 		itemList = append(itemList, []string{
 			IdFormat(item),
 			PriorityFormat(item.Priority),
-			DueDateFormat(item.DateTime(), item.AllDay),
+			DueDateFormat(dateTime, allDay),
 			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c),
 			item.LabelsString(client.Store),
 			ContentPrefix(client.Store, item, depth, c) + ContentFormat(item),

--- a/show.go
+++ b/show.go
@@ -28,13 +28,15 @@ func Show(c *cli.Context) error {
 	}
 	projectColorHash := GenerateColorHash(projectIds, colorList)
 
+	dateTime, allDay := item.DateTime()
+
 	records := [][]string{
 		[]string{"ID", IdFormat(item)},
 		[]string{"Content", ContentFormat(item)},
 		[]string{"Project", ProjectFormat(item.ProjectID, client.Store, projectColorHash, c)},
 		[]string{"Labels", item.LabelsString(client.Store)},
 		[]string{"Priority", PriorityFormat(item.Priority)},
-		[]string{"DueDate", DueDateFormat(item.DateTime(), item.AllDay)},
+		[]string{"DueDate", DueDateFormat(dateTime, allDay)},
 		[]string{"URL", todoist.GetContentURL(item)},
 	}
 	defer writer.Flush()


### PR DESCRIPTION
The `all_day` field no longer exists on Todoist sync API's Items.

As a consequence, due dates that were newly synced were always being shown as date+time, where time was always 0:00, even if the due date had no associated time.

Instead of relying on Todoist's API, this PR calculates the equivalent of `all_day` based on how the date is parsed.