### PR TITLE
File permissions of config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,6 +126,8 @@ func main() {
 
 		var token string
 
+		configFile := filepath.Join(configPath, configName+"."+configType)
+
 		if err := viper.ReadInConfig(); err != nil {
 			fmt.Printf("Input API Token: ")
 			fmt.Scan(&token)
@@ -134,10 +136,20 @@ func main() {
 			if err != nil {
 				panic(fmt.Errorf("Fatal error config file: %s \n", err))
 			}
-			err = ioutil.WriteFile(filepath.Join(configPath, configName+"."+configType), buf, os.ModePerm)
+			err = ioutil.WriteFile(configFile, buf, 0600)
 			if err != nil {
 				panic(fmt.Errorf("Fatal error config file: %s \n", err))
 			}
+		}
+
+		// Ensure that the config file has permission 0600, because it contains
+		// the API token and should only be read by the user.
+		fi, err := os.Lstat(configFile)
+		if err != nil {
+			panic(fmt.Errorf("Fatal error config file: %s \n", err))
+		}
+		if fi.Mode().Perm() != 0600 {
+			panic(fmt.Errorf("Config file has wrong permissions. Make sure to give permissions 600 to file %s \n", configFile))
 		}
 
 		config := &todoist.Config{AccessToken: viper.GetString("token"), DebugMode: c.Bool("debug"), Color: viper.GetBool("color")}


### PR DESCRIPTION
This PR addresses issue #102.

I set file permissions 0600 for config file when being created and check the permissions in each execution of the script.

**Attention**: This would be a breaking change for all those that have already created a config file which now has not permissions 0600.