### PR TITLE
Fix issue with 'go get' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:alpine
 
 RUN apk add --update git bash openssl
-RUN go get github.com/sachaos/todoist
+RUN mkdir -p $GOPATH/src/github.com/sachaos/todoist
 
 WORKDIR $GOPATH/src/github.com/sachaos/todoist
+
+RUN git clone https://github.com/sachaos/todoist.git .
 
 RUN go install
 ARG TODOIST_API_TOKEN


### PR DESCRIPTION
This PR fixes #101 which refers to an issue with `go get` in the Dockerfile. Instead of using `go get`, I follow the procedure mentioned in the readme. I first clone the git repository and then run `go install`.