### PR TITLE
Fix for url parsing in task content

### DIFF
--- a/lib/item.go
+++ b/lib/item.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	linkRegex = regexp.MustCompile(`\[(.*)\]\((.*)\)`)
+	linkRegex = regexp.MustCompile(`\[(.*?)\]\((.*?)\)`)
 )
 
 const (
@@ -127,11 +127,18 @@ func GetContentTitle(item ContentCarrier) string {
 	return linkRegex.ReplaceAllString(item.GetContent(), "$1")
 }
 
-func GetContentURL(item ContentCarrier) string {
+func GetContentURL(item ContentCarrier) []string {
 	if HasURL(item) {
-		return linkRegex.ReplaceAllString(item.GetContent(), "$2")
+		matches := linkRegex.FindAllStringSubmatch(item.GetContent(), -1)
+		if matches != nil {
+			urls := make([]string, len(matches))
+			for i, match := range matches {
+				urls[i] = match[2]
+			}
+			return urls
+		}
 	}
-	return ""
+	return []string{}
 }
 
 func HasURL(item ContentCarrier) bool {

--- a/show.go
+++ b/show.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/pkg/browser"
 	"github.com/sachaos/todoist/lib"
@@ -35,7 +36,7 @@ func Show(c *cli.Context) error {
 		[]string{"Labels", item.LabelsString(client.Store)},
 		[]string{"Priority", PriorityFormat(item.Priority)},
 		[]string{"DueDate", DueDateFormat(item.DateTime(), item.AllDay)},
-		[]string{"URL", todoist.GetContentURL(item)},
+		[]string{"URL", strings.Join(todoist.GetContentURL(item), ",")},
 	}
 	defer writer.Flush()
 
@@ -45,7 +46,9 @@ func Show(c *cli.Context) error {
 
 	if todoist.HasURL(item) {
 		if c.Bool("browse") {
-			browser.OpenURL(todoist.GetContentURL(item))
+			for _, url := range todoist.GetContentURL(item) {
+				browser.OpenURL(url)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Hi, thanks for the nice CLI tool. This pull request is intended to address the following points.

### Changes
- Fix the incorrect match of regex, when multiple URLs exist within a task (apply non-greedy match).
- Change the behavior of `GetContentURL` to return the URL itself, and also allows to extract multiple URLs.

### Behavior

For a following task string,

`Read [Todoist - Key Features](https://get.todoist.help/hc/en-us/categories/115000632125) and [Todoist - FAQ & Troubleshooting](https://get.todoist.help/hc/en-us/categories/115000626249)`

change the behavior as follows.

**Before**

```
$ todoist show 3629294999
ID       3629294999
Content  Read Todoist - Key Features](https://get.todoist.help/hc/en-us/categories/115000632125) and [Todoist - FAQ & Troubleshooting
Project  #Inbox
Labels
Priority p4
DueDate
URL      Read https://get.todoist.help/hc/en-us/categories/115000626249
```

**After**

```
$ todoist show 3629294999
ID       3629294999
Content  Read Todoist - Key Features and Todoist - FAQ & Troubleshooting
Project  #Inbox
Labels
Priority p4
DueDate
URL      https://get.todoist.help/hc/en-us/categories/115000632125,https://get.todoist.help/hc/en-us/categories/115000626249
```
