### PR TITLE
Move cache to .cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -48,14 +48,14 @@ func WriteCache(filename string, s *todoist.Store) error {
 	if err != nil {
 		return CommandFailed
 	}
-	_, err2 := os.Stat(filename)
-	if os.IsNotExist(err2) {
+	_, fileErr := os.Stat(filename)
+	if os.IsNotExist(fileErr) {
 		err = createCache(filename)
 		if err != nil {
 			return err
 		}
 	}
-	err2 = ioutil.WriteFile(filename, buf, os.ModePerm)
+	err2 := ioutil.WriteFile(filename, buf, os.ModePerm)
 	if err2 != nil {
 		return errors.New("Couldn't write to the cache file")
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	configPath, _      = os.UserHomeDir()
-	default_cache_path = filepath.Join(configPath, ".cache/todoist/cache.json")
+	default_cache_path string
 	cacheFile          = "todoist/cache.json"
 	CommandFailed      = errors.New("command failed")
 	IdNotFound         = errors.New("specified id not found")

--- a/main.go
+++ b/main.go
@@ -19,7 +19,8 @@ import (
 
 var (
 	configPath, _      = os.UserHomeDir()
-	default_cache_path = filepath.Join(configPath, ".todoist.cache.json")
+	default_cache_path = filepath.Join(configPath, ".cache/todoist/cache.json")
+	cacheFile          = "todoist/cache.json"
 	CommandFailed      = errors.New("command failed")
 	IdNotFound         = errors.New("specified id not found")
 	writer             Writer
@@ -110,6 +111,13 @@ func main() {
 			Name:  "project-namespace",
 			Usage: "display parent project like namespace",
 		},
+	}
+
+	cachePath := os.Getenv("XDG_CACHE_HOME")
+	if cachePath != "" {
+		default_cache_path = filepath.Join(cachePath, cacheFile)
+	} else {
+		default_cache_path = filepath.Join(configPath, ".cache", cacheFile)
 	}
 
 	app.Before = func(c *cli.Context) error {


### PR DESCRIPTION
This will close #118 

This will use cache from `~/.cache/todoist/cache.json` (or if you have `XDG_CACHE_HOME` then in your path)