### PR TITLE
[WIP] Implement quick add syntax

### DIFF
--- a/add.go
+++ b/add.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"strconv"
 	"strings"
+	"text/scanner"
 
 	"github.com/sachaos/todoist/lib"
 	"github.com/urfave/cli"
@@ -51,4 +54,69 @@ func Add(c *cli.Context) error {
 	}
 
 	return Sync(c)
+}
+
+var (
+	tomorrowIdentHash = map[string]bool{
+		"tomorrow": true,
+		"tom":      true,
+	}
+)
+
+func isDateIdent(token string) bool {
+	if _, ok := MonthIdentHash[token]; ok {
+		return true
+	} else if _, ok := TodayIdentHash[token]; ok {
+		return true
+	} else if _, ok := tomorrowIdentHash[token]; ok {
+		return true
+	}
+	return false
+}
+
+func QuickAdd(c *cli.Context) error {
+	client := GetClient(c)
+	item := todoist.Item{}
+
+	content := c.Args().First()
+
+	var s scanner.Scanner
+	s.Init(strings.NewReader(content))
+	for tok := s.Scan(); tok != scanner.EOF; tok = s.Scan() {
+		if s.TokenText() == "#" {
+			s.Scan()
+			project := s.TokenText()
+			projectID := client.Store.Projects.GetIDByName(project)
+			item.ProjectID = projectID
+			content = strings.Replace(content, fmt.Sprintf("#%s", project), "", 1)
+		} else if s.TokenText() == "@" {
+			s.Scan()
+			label := s.TokenText()
+			labelID := client.Store.Labels.GetIDByName(label)
+			if labelID == 0 {
+				log.Printf("Label '%s' is not known", label)
+			} else {
+				item.LabelIDs = append(item.LabelIDs, labelID)
+				content = strings.Replace(content, fmt.Sprintf("@%s", label), "", 1)
+			}
+		} else if _, ok := TodayIdentHash[s.TokenText()]; ok {
+			item.DateString = "today"
+			content = strings.Replace(content, s.TokenText(), "", 1)
+		} else if _, ok := tomorrowIdentHash[s.TokenText()]; ok {
+			item.DateString = "tomorrow"
+			content = strings.Replace(content, s.TokenText(), "", 1)
+		}
+	}
+
+	item.Content = content
+
+	if err := client.AddItem(context.Background(), item); err != nil {
+		return err
+	}
+
+	if err := Sync(c); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -218,6 +218,15 @@ func main() {
 			},
 		},
 		{
+			Name:    "quick-add",
+			Aliases: []string{"q"},
+			Usage:   "Add task using quick add syntax",
+			Action:  QuickAdd,
+			Flags: []cli.Flag{
+				reminderFlg,
+			},
+		},
+		{
 			Name:    "modify",
 			Aliases: []string{"m"},
 			Usage:   "Modify task",


### PR DESCRIPTION
Thank you for making this CLI for Todoist! It's really awesome! 

I've been playing around with implementing [quick add](https://get.todoist.help/hc/en-us/articles/115001745265-Task-Quick-Add). This is a pretty bare bones that's got it mostly working and I wanted to gauge your interest before going much further. 

So far I've found it pretty useful to add tasks fluidly (e.g. `todoist quick-add "test #Development tod"`)