### PR TITLE
Fixed documentation on Todoist filtering syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Supported filter is [here](https://github.com/sachaos/todoist/issues/15#issuecom
 #### e.g. List tasks which over due date and have high priority
 
 ```
-todoist list --filter '(overdue | today) & !p1'
+todoist list --filter '(overdue | today) & p1'
 ```
 
 ## Config


### PR DESCRIPTION
The documentation example mentions filtering by priority with `!p1`.
This used to be the case, but Todoist has dropped the exclamation mark a while ago for this filter.
`./todoist list -f '(overdue | today) & !p1'` also shoes other priorities than `p1`.
`./todoist list -f '(overdue | today) & p1'` filters correctly.