### PR TITLE
Set permissions of .todoist.config.json to 600 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN go install
 ARG TODOIST_API_TOKEN
 RUN echo '{"token": "##TOKEN##", "color":"true"}' >> $HOME/.todoist.config.json
 RUN sed -i 's|##TOKEN##|'$TODOIST_API_TOKEN'|g' $HOME/.todoist.config.json
+RUN chmod 600 $HOME/.todoist.config.json
 
 WORKDIR $GOPATH
 


### PR DESCRIPTION
Prior to this PR, I get the following error upon entering the docker container:
```ps1
PS C:\Users\felix> todoist
bash-5.0# todoist
panic: Config file has wrong permissions. Make sure to give permissions 600 to file /root/.todoist.config.json


goroutine 1 [running]:
main.main.func1(0xc0000d2840, 0xc0000d2800, 0xe)
        /go/src/github.com/sachaos/todoist/main.go:152 +0xb68
github.com/urfave/cli.(*App).Run(0xc00009f380, 0xc0000a6020, 0x2, 0x2, 0x0, 0x0)
        /go/pkg/mod/github.com/urfave/cli@v1.20.0/app.go:241 +0x7bd
main.main()
        /go/src/github.com/sachaos/todoist/main.go:290 +0x17eb
```