### PR TITLE
Start on shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Todoist CLI client
+Todoist CLI client
+===
 
 [Todoist](https://todoist.com/) CLI Client, written in Golang.
 
@@ -96,8 +97,8 @@ $ brew install todoist
 
 ### AUR
 
-- [todoist](https://aur.archlinux.org/packages/todoist/)
-- [todoist-git](https://aur.archlinux.org/packages/todoist-git/)
+* [todoist](https://aur.archlinux.org/packages/todoist/)
+* [todoist-git](https://aur.archlinux.org/packages/todoist-git/)
 
 ### Docker
 
@@ -127,7 +128,7 @@ $ make install
 ### Register API token
 
 When you run `todoist` first time, you will be asked your Todoist API token.
-Please input Todoist API token and register it. In order to get your API token
+Please input Todoist API token and register it. In order to get your API token 
 go to [https://todoist.com/prefs/integrations](https://todoist.com/prefs/integrations)
 
 ### Sync
@@ -157,13 +158,11 @@ $ source "$GOPATH/src/github.com/sachaos/todoist/todoist_functions.sh"
 If installed via homebrew and using zsh (usually this is added to your `.zshrc` without the `$`, usually before loading your ZSH plugin manager):
 
 For **peco**:
-
 ```
 $ source $(brew --prefix)/share/zsh/site-functions/_todoist_peco
 ```
 
 For **fzf**:
-
 ```
 $ source $(brew --prefix)/share/zsh/site-functions/_todoist_fzf
 ```
@@ -188,7 +187,6 @@ You can also enable shell completion by adding the following lines to your `.bas
 ```
 # Bash
 PROG=todoist source "$GOPATH/src/github.com/urfave/cli/autocomplete/bash_autocomplete"
-
 # Zsh
 PROG=todoist source "$GOPATH/src/github.com/urfave/cli/autocomplete/zsh_autocomplete"
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Todoist CLI client
-===
+# Todoist CLI client
 
 [Todoist](https://todoist.com/) CLI Client, written in Golang.
 
@@ -97,8 +96,8 @@ $ brew install todoist
 
 ### AUR
 
-* [todoist](https://aur.archlinux.org/packages/todoist/)
-* [todoist-git](https://aur.archlinux.org/packages/todoist-git/)
+- [todoist](https://aur.archlinux.org/packages/todoist/)
+- [todoist-git](https://aur.archlinux.org/packages/todoist-git/)
 
 ### Docker
 
@@ -128,7 +127,7 @@ $ make install
 ### Register API token
 
 When you run `todoist` first time, you will be asked your Todoist API token.
-Please input Todoist API token and register it. In order to get your API token 
+Please input Todoist API token and register it. In order to get your API token
 go to [https://todoist.com/prefs/integrations](https://todoist.com/prefs/integrations)
 
 ### Sync
@@ -158,11 +157,13 @@ $ source "$GOPATH/src/github.com/sachaos/todoist/todoist_functions.sh"
 If installed via homebrew and using zsh (usually this is added to your `.zshrc` without the `$`, usually before loading your ZSH plugin manager):
 
 For **peco**:
+
 ```
 $ source $(brew --prefix)/share/zsh/site-functions/_todoist_peco
 ```
 
 For **fzf**:
+
 ```
 $ source $(brew --prefix)/share/zsh/site-functions/_todoist_fzf
 ```
@@ -178,6 +179,18 @@ $ source $(brew --prefix)/share/zsh/site-functions/_todoist_fzf
 <C-x> t c: select task and close with peco
 <C-x> t d: select date
 <C-x> t o: select task, and open it with browser when has url
+```
+
+### Enable shell completion
+
+You can also enable shell completion by adding the following lines to your `.bashrc`/`.zshrc` files.
+
+```
+# Bash
+PROG=todoist source "$GOPATH/src/github.com/urfave/cli/autocomplete/bash_autocomplete"
+
+# Zsh
+PROG=todoist source "$GOPATH/src/github.com/urfave/cli/autocomplete/zsh_autocomplete"
 ```
 
 ## Author

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/fatih/color"
-	todoist "github.com/sachaos/todoist/lib"
+	"github.com/sachaos/todoist/lib"
 	"github.com/spf13/viper"
 	"github.com/urfave/cli"
 )
@@ -255,17 +255,17 @@ func main() {
 			Action: Projects,
 		},
 		{
-			Name:    "add-project",
-			Aliases: []string{"ap"},
-			Usage:   "Add new project",
-			Action:  AddProject,
+			Name:	"add-project",
+			Aliases:[]string{"ap"},
+			Usage:	"Add new project",
+			Action:	AddProject,
 			Flags: []cli.Flag{
 				cli.IntFlag{
-					Name:  "color",
+					Name: "color",
 					Usage: "In range 30-49",
 				},
 				cli.IntFlag{
-					Name:  "item-order",
+					Name: "item-order",
 					Usage: "Order index",
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/fatih/color"
-	"github.com/sachaos/todoist/lib"
+	todoist "github.com/sachaos/todoist/lib"
 	"github.com/spf13/viper"
 	"github.com/urfave/cli"
 )
@@ -42,6 +42,7 @@ func main() {
 	app.Name = "todoist"
 	app.Usage = "Todoist CLI Client"
 	app.Version = "0.15.0"
+	app.EnableBashCompletion = true
 
 	contentFlag := cli.StringFlag{
 		Name:  "content, c",
@@ -254,17 +255,17 @@ func main() {
 			Action: Projects,
 		},
 		{
-			Name:	"add-project",
-			Aliases:[]string{"ap"},
-			Usage:	"Add new project",
-			Action:	AddProject,
+			Name:    "add-project",
+			Aliases: []string{"ap"},
+			Usage:   "Add new project",
+			Action:  AddProject,
 			Flags: []cli.Flag{
 				cli.IntFlag{
-					Name: "color",
+					Name:  "color",
 					Usage: "In range 30-49",
 				},
 				cli.IntFlag{
-					Name: "item-order",
+					Name:  "item-order",
 					Usage: "Order index",
 				},
 			},


### PR DESCRIPTION
It is possible to add some autocompletion to the shell by setting the `app.EnableBashCompletion = true` flag.

https://github.com/urfave/cli/blob/master/docs/v1/manual.md#bash-completion

This autocompletes subcommands automatically.

![image](https://user-images.githubusercontent.com/1610850/88046253-b51e4d80-cb47-11ea-93cf-ea4b248d539e.png)

This seems to have picked up a bunch of short alias commands too, so that might need tidying up.

It would also be nice in the future to add custom handlers which would for autocompleting things like `todoist delete <task id>` where a list of tasks would be shown.

I just wanted to raise this to get the ball rolling on adding autocompletion.

Related to #126