### PR TITLE
support section name displaying in list command

### DIFF
--- a/format.go
+++ b/format.go
@@ -105,6 +105,17 @@ func ProjectFormat(id int, store *todoist.Store, projectColorHash map[int]color.
 	return prefix + color.New(projectColorHash[project.GetID()]).SprintFunc()("#"+namePrefix+projectName)
 }
 
+func SectionFormat(id int, store *todoist.Store, c *cli.Context) string {
+	prefix := ""
+	sectionName := ""
+	section := store.FindSection(id)
+	if section != nil {
+		prefix = "/"
+		sectionName = section.Name
+	}
+	return prefix + sectionName
+}
+
 func dueDateString(dueDate time.Time, allDay bool) string {
 	if (dueDate == time.Time{}) {
 		return ""

--- a/lib/interface.go
+++ b/lib/interface.go
@@ -13,6 +13,10 @@ type HaveProjectID struct {
 	ProjectID int `json:"project_id"`
 }
 
+type HaveSectionID struct {
+	SectionID int `json:"section_id"`
+}
+
 type HaveIndent struct {
 	Indent int `json:"indent"`
 }

--- a/lib/item.go
+++ b/lib/item.go
@@ -62,6 +62,7 @@ type Item struct {
 	BaseItem
 	HaveParentID
 	HaveIndent
+	HaveSectionID
 	ChildItem      *Item       `json:"-"`
 	BrotherItem    *Item       `json:"-"`
 	AllDay         bool        `json:"all_day"`

--- a/lib/section.go
+++ b/lib/section.go
@@ -1,0 +1,13 @@
+package todoist
+
+type Section struct {
+	HaveID
+	HaveProjectID
+	Collapsed    bool   `json:"collapsed"`
+	Name         string `json:"name"`
+	IsArchived   bool   `json:"is_archived"`
+	IsDeleted    bool   `json:"is_deleted"`
+	SectionOrder int    `json:"section_order"`
+}
+
+type Sections []Section

--- a/lib/sync.go
+++ b/lib/sync.go
@@ -45,6 +45,7 @@ type Store struct {
 	} `json:"notes"`
 	ProjectNotes []interface{} `json:"project_notes"`
 	Projects     Projects      `json:"projects"`
+	Sections     Sections      `json:"sections"`
 	Reminders    []struct {
 		DateLang     string `json:"date_lang"`
 		Due          *Due   `json:"due"`
@@ -64,6 +65,7 @@ type Store struct {
 	ItemMap       map[int]*Item    `json:"-"`
 	ProjectMap    map[int]*Project `json:"-"`
 	LabelMap      map[int]*Label   `json:"-"`
+	SectionMap    map[int]*Section `json:"-"`
 }
 
 func (s *Store) FindItem(id int) *Item {
@@ -72,6 +74,10 @@ func (s *Store) FindItem(id int) *Item {
 
 func (s *Store) FindProject(id int) *Project {
 	return s.ProjectMap[id]
+}
+
+func (s *Store) FindSection(id int) *Section {
+	return s.SectionMap[id]
 }
 
 func (s *Store) FindLabel(id int) *Label {
@@ -120,6 +126,7 @@ func (s *Store) ConstructItemTree() {
 	s.LabelMap = map[int]*Label{}
 	s.ProjectMap = map[int]*Project{}
 	s.ItemMap = map[int]*Item{}
+	s.SectionMap = map[int]*Section{}
 
 	for i, label := range s.Labels {
 		s.LabelMap[label.ID] = &s.Labels[i]
@@ -135,6 +142,10 @@ func (s *Store) ConstructItemTree() {
 		s.ProjectMap[project.ID] = &s.Projects[i]
 		s.Projects[i].ChildProject = nil
 		s.Projects[i].BrotherProject = nil
+	}
+
+	for i, section := range s.Sections {
+		s.SectionMap[section.ID] = &s.Sections[i]
 	}
 
 	for _, item := range s.Items {

--- a/list.go
+++ b/list.go
@@ -11,7 +11,7 @@ func traverseItems(item *todoist.Item, f func(item *todoist.Item, depth int), de
 	f(item, depth)
 
 	if item.ChildItem != nil {
-		traverseItems(item.ChildItem, f, depth + 1)
+		traverseItems(item.ChildItem, f, depth+1)
 	}
 
 	if item.BrotherItem != nil {
@@ -51,7 +51,8 @@ func List(c *cli.Context) error {
 			IdFormat(item),
 			PriorityFormat(item.Priority),
 			DueDateFormat(item.DateTime(), item.AllDay),
-			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c),
+			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c) +
+				SectionFormat(item.SectionID, client.Store, c),
 			item.LabelsString(client.Store),
 			ContentPrefix(client.Store, item, depth, c) + ContentFormat(item),
 		})


### PR DESCRIPTION
Section can be used as subproject in Todoist. So section field is added in cache file and also section name will be displayed after project name when using "list" command just like how the Todoist web application is doing. 

Adding/deleting sections feature will be added later. 