### PR TITLE
Remove config perm check for Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 		if err != nil {
 			panic(fmt.Errorf("Fatal error config file: %s \n", err))
 		}
-		if fi.Mode().Perm() != 0600 {
+		if runtime.GOOS != "windows" && fi.Mode().Perm() != 0600 {
 			panic(fmt.Errorf("Config file has wrong permissions. Make sure to give permissions 600 to file %s \n", configFile))
 		}
 


### PR DESCRIPTION
I'm not a Go developer, but I looked at the other open PR for this issue and it seems too complicated. All I'm doing here is adding an additional condition to `if` statement that avoids checking for a value of `0600` if the currently running OS is Windows. If you want to implement a different solution for this, feel free to close the PR.