### PR TITLE
Allow setting config values via environment variables

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -54,7 +54,7 @@ func AssureExists(filePath string) error {
 	if !exists {
 		err = os.MkdirAll(path, os.ModePerm)
 		if err != nil {
-			return fmt.Errorf("Couldn't create file: %s", filePath)
+			return fmt.Errorf("Couldn't create path: %s", path)
 		}
 	}
 	return nil


### PR DESCRIPTION
Hey sachaos, first of all thanks a lot for this tool, it is already of great use to me!

I propose a change to allow users to set configuration values (especially the API token) via environment variables. Depending on one's personal setup, this makes it much easier to inject secrets from password stores/vaults instead of storing them in the `.config` directory.

The library `viper` which is used to manage the app's config already supports environment variables, which makes it much easier to implement this change. I additionally tried to keep the existing logic for initializing the config file interactively if it hasn't been found on disk.

My code is still rough on the edges, but i wanted to ask you first if there is any interest in this change before cleaning it up. I also have to admit that I am fairly new to Golang, I am sorry in advance for any stupidity from my side.

Thanks a lot for looking into it,
Cheers, remolueoend