### PR TITLE
section_id is messed up when listing items

### DIFF
--- a/format.go
+++ b/format.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/sachaos/todoist/lib"
+	todoist "github.com/sachaos/todoist/lib"
 	"github.com/urfave/cli"
 )
 
@@ -105,15 +105,21 @@ func ProjectFormat(id int, store *todoist.Store, projectColorHash map[int]color.
 	return prefix + color.New(projectColorHash[project.GetID()]).SprintFunc()("#"+namePrefix+projectName)
 }
 
-func SectionFormat(id int, store *todoist.Store, c *cli.Context) string {
-	prefix := ""
-	sectionName := ""
-	section := store.FindSection(id)
-	if section != nil {
-		prefix = "/"
-		sectionName = section.Name
+func SectionFormat(id interface{}, store *todoist.Store, c *cli.Context) string {
+	if id == nil {
+		return ""
+	} else {
+		prefix := ""
+		sectionName := ""
+		// section id is an empty interface, it will be unmarshalled as float64 instead of int
+		// refer to https://golang.org/pkg/encoding/json/#Unmarshal for details
+		section := store.FindSection(int(id.(float64)))
+		if section != nil {
+			prefix = "/"
+			sectionName = section.Name
+		}
+		return prefix + sectionName
 	}
-	return prefix + sectionName
 }
 
 func dueDateString(dueDate time.Time, allDay bool) string {

--- a/lib/interface.go
+++ b/lib/interface.go
@@ -13,8 +13,9 @@ type HaveProjectID struct {
 	ProjectID int `json:"project_id"`
 }
 
+// HaveSectionID defines the ID of the section that item belongs to, it can be emtpy(nul)
 type HaveSectionID struct {
-	SectionID int `json:"section_id"`
+	SectionID interface{} `json:"section_id"`
 }
 
 type HaveIndent struct {


### PR DESCRIPTION
If an item does not belong to any section, the section ID will be null, the previous change didn't take this into consideration, which would cause messing up of sections for items. 

Changed the type of section_id from int to empty interface to fix this bug
