### PR TITLE
Support sorting by dates

### DIFF
--- a/list.go
+++ b/list.go
@@ -21,6 +21,9 @@ func traverseItems(item *todoist.Item, f func(item *todoist.Item, depth int), de
 	}
 }
 
+var byPriority int = 1
+var byDate int = 2
+
 func sortItems(itemListPtr *[][]string, byIndex int) {
 	itemList := *itemListPtr
 	length := len(itemList)
@@ -74,10 +77,20 @@ func List(c *cli.Context) error {
 		})
 	}, 0)
 
-	if c.Bool("priority") == true {
-		// sort output by priority
-		// and no need to use "else block" as items returned by API are already sorted by task id
-		sortItems(&itemList, 1)
+	switch c.String("sort") {
+	case "priority":
+		sortItems(&itemList, byPriority)
+		break
+	case "date":
+		sortItems(&itemList, byDate)
+		break
+	default:
+		// For backwards compatibility, can be removed when users have had time
+		// to migrate.
+		if c.Bool("priority") == true {
+			sortItems(&itemList, byPriority)
+		}
+
 	}
 
 	defer writer.Flush()

--- a/main.go
+++ b/main.go
@@ -81,7 +81,11 @@ func main() {
 	}
 	sortPriorityFlag := cli.BoolFlag{
 		Name:  "priority, p",
-		Usage: "sort the output by priority",
+		Usage: "(Deprecated, prefer --sort)",
+	}
+	sortFlag := cli.StringFlag{
+		Name:  "sort",
+    Usage: "sort the output by the desired parameter `(date|priority)`",
 	}
 	reminderFlg := cli.BoolFlag{
 		Name:  "reminder, r",
@@ -207,6 +211,7 @@ func main() {
 			Flags: []cli.Flag{
 				filterFlag,
 				sortPriorityFlag,
+				sortFlag,
 			},
 			ArgsUsage: " ",
 		},


### PR DESCRIPTION
**Why** is the change needed?

That's very fundamental to how I use Todoist since I assign each task
with a timestamp and rely on them appearing ordered by date.

**How** is the need addressed?

-   Replace `--priority` flag with `--sort (date|priority)` for better
    extensibility
-   Label the `--priority` flag as deprecated

What **side-effects** could the change have?

-  Clutters the code base until the `--priority` flag can be removed.
   Still better than breaking changes. Can be removed after a reasonable
   migration time.