### PR TITLE
Basic autocomplete for zsh

### DIFF
--- a/todoist_autocomplete.sh
+++ b/todoist_autocomplete.sh
@@ -1,0 +1,26 @@
+#compdef todoist
+
+_cli_zsh_autocomplete() {
+
+  _arguments -C \
+    '1:cmd:->cmds' \
+    '2:close:->tasks' \
+    '*:: :->args' \
+  && ret=0
+
+  case "$state" in
+    (cmds)
+      local -a commands;
+      commands=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+      _describe -t commands 'command' commands && ret=0
+    ;;
+    (tasks)
+      local -a tasks; tasks=("${(@f)$(todoist l | sed 's/\s/:/')}")
+      _describe -t tasks 'task' tasks && ret=0
+    ;;
+  esac
+
+  return 1
+}
+
+compdef _cli_zsh_autocomplete todoist


### PR DESCRIPTION
Hey @sachaos!

For my own utility I have added autocomplete for zsh which can complete task ids. 

```
➜  todoist close <TAB>
5403125414  -- p4  #Inbox  task 1
5427978770  -- p4  #Inbox  task 2
5427978970  -- p4  #Inbox  task 3
5427979275  -- p4  #Inbox  task 4
5431762171  -- p4  #Inbox  task 5
5431762310  -- p4  #Inbox  task 6
``` 

It is not ready for general usage, because it suggests all options go cli provides for first option and tasks for the second.

So if you do 
```
➜  todoist --csv <TAB>
5403125414  -- p4  #Inbox  task 1
5427978770  -- p4  #Inbox  task 2
5427978970  -- p4  #Inbox  task 3
```
you will also get tasks instead of commands.

Zsh autocomplete is smarter than this, but its a start.