### PR TITLE
Fix cli version in help

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "todoist"
 	app.Usage = "Todoist CLI Client"
-	app.Version = "0.15.0"
+	app.Version = "0.16.0"
 	app.EnableBashCompletion = true
 
 	contentFlag := cli.StringFlag{


### PR DESCRIPTION
Hi! Thanks for great cli! I noticed that after the release of 0.16.0, the version in the help has not changed.