### PR TITLE
Add a raw flag to the completed command

### DIFF
--- a/completed.go
+++ b/completed.go
@@ -18,6 +18,7 @@ func CompletedList(c *cli.Context) error {
 	}
 	projectColorHash := GenerateColorHash(projectIds, colorList)
 	ex := Filter(c.String("filter"))
+	rawFilter := c.String("raw")
 
 	var completed todoist.Completed
 
@@ -39,11 +40,19 @@ func CompletedList(c *cli.Context) error {
 		if !result {
 			continue
 		}
+
+		itemText := ""
+		if rawFilter == "true" {
+			itemText = item.GetContent()
+		} else {
+			itemText = ContentFormat(item)
+		}
+
 		writer.Write([]string{
 			IdFormat(item),
 			CompletedDateFormat(item.DateTime()),
 			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c),
-			ContentFormat(item),
+			itemText,
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -87,6 +87,10 @@ func main() {
 		Name:  "reminder, r",
 		Usage: "set reminder (only premium users)",
 	}
+	rawFlag := cli.BoolFlag{
+		Name:  "raw",
+		Usage: "Show raw content, as you would see it when you edit.",
+	}
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
@@ -226,6 +230,7 @@ func main() {
 			Action:  CompletedList,
 			Flags: []cli.Flag{
 				filterFlag,
+				rawFlag,
 			},
 			ArgsUsage: " ",
 		},


### PR DESCRIPTION
Fixes #182

This command outputs the raw markdown one can see when editing a task.

## To test:
1. Create a task that has some markdown in it. Example:

```
[markdown link](https://github.com/)
```

2. Mark that task as completed.

3. From the project root run `go run . sync `

4. From the project root run `go run . cl` and notice that you'll only see `markdown link`

5. From the project root run `go run . cl --raw ` and notice the markdown shows, exposing the link to github.com.