### PR TITLE
Fix version variable for 0.16.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "todoist"
 	app.Usage = "Todoist CLI Client"
-	app.Version = "0.15.0"
+	app.Version = "0.16.0"
 	app.EnableBashCompletion = true
 
 	contentFlag := cli.StringFlag{


### PR DESCRIPTION
`todoist -v` returns the wrong version number on tag 0.16.0.
I did not test this locally, just edited through Github.