### PR TITLE
fix(issue-#216): resolves modifying and setting date on task creation

### DIFF
--- a/add.go
+++ b/add.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	todoist "github.com/sachaos/todoist/lib"
+	"github.com/sachaos/todoist/lib"
 	"github.com/urfave/cli/v2"
 )
 
@@ -38,10 +38,7 @@ func Add(c *cli.Context) error {
 		return names
 	}(c.String("label-names"))
 
-	due := todoist.Due{
-		String: c.String("date"),
-	}
-	item.Due = &due
+	item.Due = &todoist.Due{String: c.String("date")}
 
 	item.AutoReminder = c.Bool("reminder")
 

--- a/add.go
+++ b/add.go
@@ -38,7 +38,11 @@ func Add(c *cli.Context) error {
 		return names
 	}(c.String("label-names"))
 
-	item.DateString = c.String("date")
+	due := todoist.Due{
+		String: c.String("date"),
+	}
+	item.Due = &due
+
 	item.AutoReminder = c.Bool("reminder")
 
 	if err := client.AddItem(context.Background(), item); err != nil {

--- a/lib/item.go
+++ b/lib/item.go
@@ -167,6 +167,9 @@ func (item Item) AddParam() interface{} {
 	if item.ProjectID != "" {
 		param["project_id"] = item.ProjectID
 	}
+	if item.Due != nil {
+		param["due"] = item.Due
+	}
 	param["auto_reminder"] = item.AutoReminder
 
 	return param
@@ -192,6 +195,9 @@ func (item Item) UpdateParam() interface{} {
 	}
 	if item.Priority != 0 {
 		param["priority"] = item.Priority
+	}
+	if item.Due != nil {
+		param["due"] = item.Due
 	}
 	return param
 }

--- a/modify.go
+++ b/modify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/sachaos/todoist/lib"
 	"github.com/urfave/cli/v2"
 )
 
@@ -34,7 +35,10 @@ func Modify(c *cli.Context) error {
 		return names
 	}(c.String("label-names"))
 
-	item.DateString = c.String("date")
+	due := todoist.Due{
+		String: c.String("date"),
+	}
+	item.Due = &due
 
 	projectID := c.String("project-id")
 	if projectID == "" {

--- a/modify.go
+++ b/modify.go
@@ -35,10 +35,7 @@ func Modify(c *cli.Context) error {
 		return names
 	}(c.String("label-names"))
 
-	due := todoist.Due{
-		String: c.String("date"),
-	}
-	item.Due = &due
+	item.Due = &todoist.Due{String: c.String("date")}
 
 	projectID := c.String("project-id")
 	if projectID == "" {


### PR DESCRIPTION
Changed [lib/item.go](https://github.com/sachaos/todoist/blob/master/lib/item.go) to send [Due struct](https://github.com/sachaos/todoist/blob/b057a90ebcbaa28788e136795ebd385b68b8b5af/lib/item.go#L20-L26) in [params ](https://github.com/sachaos/todoist/blob/b057a90ebcbaa28788e136795ebd385b68b8b5af/lib/item.go#L153-L198)for adding and updating tasks. Changed `add.go` and `modify.go` to create a Due struct and add said Due struct to Item struct instead of setting `item.Datestring`. This change is due to an API change by Todoist.

I did have to bring the library into `modify.go` so I could create the Due struct. It was already referenced for other purposes in `add.go`

There may be a better way to do this, it seems a bit messy to me, so I'm (always) open to feedback. 