### PR TITLE
v0.19.0 was released without updating the hard-coded app.Version, so …

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "todoist"
 	app.Usage = "Todoist CLI Client"
-	app.Version = "0.18.0"
+	app.Version = "0.20.0"
 	app.EnableBashCompletion = true
 
 	contentFlag := cli.StringFlag{


### PR DESCRIPTION
…updating to 0.20.0 in anticipation of another release

fixes #224 