### PR TITLE
fix(main.go): resync if cached token is not equal to the configured token

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,6 +193,13 @@ func main() {
 			"config": config,
 		}
 
+		if config.AccessToken != store.User.Token {
+			Sync(c)
+			if err := LoadCache(cachePath, &store); err != nil {
+				return err
+			}
+		}
+
 		if !c.Bool("color") && !config.Color {
 			color.NoColor = true
 		} else {


### PR DESCRIPTION
Updated the Before call to check if the configured token matches the cached token. If it doesn't, resync and reload the cache before performing the requested operation