### PR TITLE
Added check for project color non-existant

### DIFF
--- a/add_project.go
+++ b/add_project.go
@@ -16,7 +16,10 @@ func AddProject(c *cli.Context) error {
 	}
 
 	project.Name = c.Args().First()
-	project.Color = c.String("color")
+
+	if c.String("color") != "0" {
+		project.Color = c.String("color")
+	}
 	project.ItemOrder = c.Int("item-order")
 
 	if err := client.AddProject(context.Background(), project); err != nil {


### PR DESCRIPTION
Updated add project to check if color doesn't exist, to elimiate the issues of passing `0` to the api, which is causing an issue. Resolves issue #244