### PR TITLE
Fix README brew install command for Todoist CLI to avoid cask-formula conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ It has following parameters:
 ### Homebrew (Mac OS)
 
 ```
-$ brew tap sachaos/todoist
-$ brew install todoist
+$ brew install sachaos/todoist/todoist
 ```
 
 ### AUR


### PR DESCRIPTION
### Fix README for Homebrew Installation Command

#### Problem
The current README suggests using `brew install todoist`, which defaults to installing the cask (GUI application) rather than the formula (CLI tool). This can cause confusion for users looking to install the CLI tool.

#### Solution
This PR updates the installation instructions in the README to explicitly specify the correct command for the CLI tool:
- Use `brew install sachaos/todoist/todoist` for the CLI tool.

![image](https://github.com/user-attachments/assets/48c82e00-ab62-41e1-8c6b-d8d5e9de8319)
