### PR TITLE
Add autocomplete files to archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,12 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
+    files:
+      - LICENSE
+      - README.md
+      - todoist_functions.sh
+      - todoist_functions_fzf.sh
+      - todoist_functions_fzf_bash.sh
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
The autocomplete files are missing from the released archives. This causes a failure in the brew install/updates:

Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - todoist_functions.sh

Although todoist_functions_fzf_bash.sh is not needed, added for completeness for those using Bash.