### PR TITLE
Simplify label -> name logic

### DIFF
--- a/lib/item.go
+++ b/lib/item.go
@@ -210,20 +210,8 @@ func (item *Item) MoveParam(projectId string) interface{} {
 	return param
 }
 
-func (item Item) LabelsString(store *Store) string {
-	var b strings.Builder
-	labelIDs := []string{}
-	for _, labelName := range item.LabelNames {
-		labelIDs = append(labelIDs, store.Labels.GetIDByName(labelName))
-	}
-	for i, labelId := range labelIDs {
-		label := store.FindLabel(labelId)
-		b.WriteString("@" + label.Name)
-		if i < len(labelIDs)-1 {
-			b.WriteString(",")
-		}
-	}
-	return b.String()
+func (item Item) LabelsString() string {
+	return "@" + strings.Join(item.LabelNames, ",@")
 }
 
 func (c *Client) AddItem(ctx context.Context, item Item) error {

--- a/list.go
+++ b/list.go
@@ -69,7 +69,7 @@ func List(c *cli.Context) error {
 			DueDateFormat(item.DateTime(), item.AllDay),
 			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c) +
 				SectionFormat(item.SectionID, client.Store, c),
-			item.LabelsString(client.Store),
+			item.LabelsString(),
 			ContentPrefix(client.Store, item, depth, c) + ContentFormat(item),
 		})
 	}, 0)

--- a/show.go
+++ b/show.go
@@ -29,7 +29,7 @@ func Show(c *cli.Context) error {
 		[]string{"ID", IdFormat(item)},
 		[]string{"Content", ContentFormat(item)},
 		[]string{"Project", ProjectFormat(item.ProjectID, client.Store, projectColorHash, c)},
-		[]string{"Labels", item.LabelsString(client.Store)},
+		[]string{"Labels", item.LabelsString()},
 		[]string{"Priority", PriorityFormat(item.Priority)},
 		[]string{"DueDate", DueDateFormat(item.DateTime(), item.AllDay)},
 		[]string{"URL", strings.Join(todoist.GetContentURL(item), ",")},


### PR DESCRIPTION
This solves the crash in #272. Reading through the git blame, it seemed like the labels going from name -> id -> name was a holdover of some old code. I just cut out the last two steps. 