### PR TITLE
fix: only update item fields when flags are explicitly set

### DIFF
--- a/modify.go
+++ b/modify.go
@@ -24,18 +24,28 @@ func Modify(c *cli.Context) error {
 	if item == nil {
 		return IdNotFound
 	}
-	item.Content = c.String("content")
-	item.Priority = priorityMapping[c.Int("priority")]
-	item.LabelNames = func(str string) []string {
-		stringNames := strings.Split(str, ",")
-		names := []string{}
-		for _, stringName := range stringNames {
-			names = append(names, stringName)
-		}
-		return names
-	}(c.String("label-names"))
+	if c.IsSet("content") {
+		item.Content = c.String("content")
+	}
+	if c.IsSet("priority") {
+		item.Priority = priorityMapping[c.Int("priority")]
+	}
+	if c.IsSet("label-names") {
+		item.LabelNames = func(str string) []string {
+			stringNames := strings.Split(str, ",")
+			names := []string{}
+			for _, stringName := range stringNames {
+				if stringName != "" {
+					names = append(names, stringName)
+				}
+			}
+			return names
+		}(c.String("label-names"))
+	}
 
-	item.Due = &todoist.Due{String: c.String("date")}
+	if c.IsSet("date") {
+		item.Due = &todoist.Due{String: c.String("date")}
+	}
 
 	projectID := c.String("project-id")
 	if projectID == "" {


### PR DESCRIPTION
## Summary

- Fix `todoist modify` overwriting all item fields with empty values when flags aren't provided
- Only update content, priority, labels, and due date when their respective flags are explicitly set
- Filter empty strings from label-names to prevent sending `[""]` to the API

## Problem

Previously, running `todoist modify abc123 -d tomorrow` would:
- ✅ Set due date to "tomorrow"
- ❌ Clear content to ""
- ❌ Clear labels to empty
- ❌ Reset priority to 0

This happened because the code unconditionally overwrote all fields regardless of whether flags were provided.

## Solution

Use `c.IsSet()` to check if each flag was explicitly provided before modifying the corresponding field.

## Test plan

- [ ] Run `todoist modify <id> -d tomorrow` and verify only due date changes
- [ ] Run `todoist modify <id> -c "new content"` and verify only content changes
- [ ] Run `todoist modify <id> -p 1` and verify only priority changes
- [ ] Run `todoist modify <id> --label-names "label1,label2"` and verify only labels change