### PR TITLE
fix: update AUR package link from todoist to todoist-bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ brew install sachaos/todoist/todoist
 
 ### AUR
 
-* [todoist](https://aur.archlinux.org/packages/todoist/)
+* [todoist-bin](https://aur.archlinux.org/packages/todoist-bin/)
 * [todoist-git](https://aur.archlinux.org/packages/todoist-git/)
 
 ### Nix/NixOS


### PR DESCRIPTION
The `todoist` AUR package no longer exists (returns 404). The correct package name is `todoist-bin`.

https://aur.archlinux.org/packages/todoist-bin/