### PR TITLE
Fix: Prevent empty labels from rendering as a stray @

### DIFF
--- a/lib/item.go
+++ b/lib/item.go
@@ -211,6 +211,9 @@ func (item *Item) MoveParam(projectId string) interface{} {
 }
 
 func (item Item) LabelsString() string {
+	if len(item.LabelNames) == 0 {
+		return ""
+	}
 	return "@" + strings.Join(item.LabelNames, ",@")
 }
 

--- a/lib/item_test.go
+++ b/lib/item_test.go
@@ -1,0 +1,26 @@
+package todoist
+
+import (
+	"testing"
+)
+
+func TestItem_LabelsString(t *testing.T) {
+	item1 := Item{
+		LabelNames: []string{"important", "work", "unknown_label"},
+	}
+
+	expected1 := "@important,@work,@unknown_label"
+	result1 := item1.LabelsString()
+	if result1 != expected1 {
+		t.Errorf("expected %s, got %s", expected1, result1)
+	}
+
+	item2 := Item{
+		LabelNames: []string{},
+	}
+	expected2 := ""
+	result2 := item2.LabelsString()
+	if result2 != expected2 {
+		t.Errorf("expected %q, got %q", expected2, result2)
+	}
+}

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -77,7 +77,7 @@ func (c *Client) doApi(ctx context.Context, method string, uri string, params ur
 	c.Log("response: %#v", resp)
 
 	if resp.StatusCode != http.StatusOK {
-		c.Log(ParseAPIError("bad request", resp).Error())
+		c.Log("%s", ParseAPIError("bad request", resp).Error())
 		return ParseAPIError("bad request", resp)
 	} else if res == nil {
 		return nil
@@ -125,7 +125,7 @@ func (c *Client) doRestApi(ctx context.Context, method string, uri string, body 
 	c.Log("response: %#v", resp)
 
 	if resp.StatusCode != http.StatusOK {
-		c.Log(ParseAPIError("bad request", resp).Error())
+		c.Log("%s", ParseAPIError("bad request", resp).Error())
 		return ParseAPIError("bad request", resp)
 	} else if res == nil {
 		return nil


### PR DESCRIPTION
## Description

A recent change to `LabelsString()` removed the cache lookup and simply concatenates label names with an `@` prefix. However, if an item has zero labels, `strings.Join([]string{}, ",@")` returns an empty string, which gets prefixed with `@`. This results in every label-less item showing a stray `@` symbol in the CLI output.

### Changes:
- Added an early return (`""`) when the label list is empty.
- Added a unit test `TestItem_LabelsString` to cover this exact edge case (both populated and empty states).
- Also fixed a `go vet` issue in `todoist.go` that prevented the test suite from successfully compiling (the string formatter in `c.Log`).