### PR TITLE
Add configurable api_url for proxy support

### DIFF
--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -17,12 +17,12 @@ type Config struct {
 	Color          bool
 	DateFormat     string
 	DateTimeFormat string
-	BaseURL        string
+	APIURL         string
 }
 
 func (c *Client) baseURL() string {
-	if c.config.BaseURL != "" {
-		return c.config.BaseURL
+	if c.config.APIURL != "" {
+		return c.config.APIURL
 	}
 	return Server
 }

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -17,6 +17,14 @@ type Config struct {
 	Color          bool
 	DateFormat     string
 	DateTimeFormat string
+	BaseURL        string
+}
+
+func (c *Client) baseURL() string {
+	if c.config.BaseURL != "" {
+		return c.config.BaseURL
+	}
+	return Server
 }
 
 type Client struct {
@@ -40,7 +48,7 @@ func (c *Client) Log(format string, v ...interface{}) {
 
 func (c *Client) doApi(ctx context.Context, method string, uri string, params url.Values, res interface{}) error {
 	c.Log("doAPi: called")
-	u, err := url.Parse(Server)
+	u, err := url.Parse(c.baseURL())
 	if err != nil {
 		return err
 	}
@@ -87,7 +95,7 @@ func (c *Client) doApi(ctx context.Context, method string, uri string, params ur
 
 func (c *Client) doRestApi(ctx context.Context, method string, uri string, body interface{}, res interface{}) error {
 	c.Log("doRestApi: called")
-	u, err := url.Parse(Server)
+	u, err := url.Parse(c.baseURL())
 	if err != nil {
 		return err
 	}

--- a/lib/todoist_test.go
+++ b/lib/todoist_test.go
@@ -17,7 +17,7 @@ func TestBaseURL_Default(t *testing.T) {
 
 func TestBaseURL_Custom(t *testing.T) {
 	custom := "https://proxy.example.com/api/v1/"
-	client := NewClient(&Config{AccessToken: "token", BaseURL: custom})
+	client := NewClient(&Config{AccessToken: "token", APIURL: custom})
 	if client.baseURL() != custom {
 		t.Errorf("expected %s, got %s", custom, client.baseURL())
 	}
@@ -32,7 +32,7 @@ func TestDoApi_UsesCustomBaseURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(&Config{AccessToken: "token", BaseURL: srv.URL + "/api/v1/"})
+	client := NewClient(&Config{AccessToken: "token", APIURL: srv.URL + "/api/v1/"})
 	client.doApi(context.Background(), http.MethodPost, "sync", url.Values{"sync_token": {"*"}}, nil)
 
 	if gotPath != "/api/v1/sync" {
@@ -49,7 +49,7 @@ func TestDoRestApi_UsesCustomBaseURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(&Config{AccessToken: "token", BaseURL: srv.URL + "/api/v1/"})
+	client := NewClient(&Config{AccessToken: "token", APIURL: srv.URL + "/api/v1/"})
 	client.doRestApi(context.Background(), http.MethodPost, "tasks/quick", nil, nil)
 
 	if gotPath != "/api/v1/tasks/quick" {

--- a/lib/todoist_test.go
+++ b/lib/todoist_test.go
@@ -1,0 +1,58 @@
+package todoist
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestBaseURL_Default(t *testing.T) {
+	client := NewClient(&Config{AccessToken: "token"})
+	if client.baseURL() != Server {
+		t.Errorf("expected %s, got %s", Server, client.baseURL())
+	}
+}
+
+func TestBaseURL_Custom(t *testing.T) {
+	custom := "https://proxy.example.com/api/v1/"
+	client := NewClient(&Config{AccessToken: "token", BaseURL: custom})
+	if client.baseURL() != custom {
+		t.Errorf("expected %s, got %s", custom, client.baseURL())
+	}
+}
+
+func TestDoApi_UsesCustomBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(&Config{AccessToken: "token", BaseURL: srv.URL + "/api/v1/"})
+	client.doApi(context.Background(), http.MethodPost, "sync", url.Values{"sync_token": {"*"}}, nil)
+
+	if gotPath != "/api/v1/sync" {
+		t.Errorf("expected request to /api/v1/sync, got %s", gotPath)
+	}
+}
+
+func TestDoRestApi_UsesCustomBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	client := NewClient(&Config{AccessToken: "token", BaseURL: srv.URL + "/api/v1/"})
+	client.doRestApi(context.Background(), http.MethodPost, "tasks/quick", nil, nil)
+
+	if gotPath != "/api/v1/tasks/quick" {
+		t.Errorf("expected request to /api/v1/tasks/quick, got %s", gotPath)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func main() {
 				panic(fmt.Errorf("Config file has wrong permissions. Make sure to give permissions 600 to file %s \n", configFile))
 			}
 		}
-		config := &todoist.Config{AccessToken: viper.GetString("token"), DebugMode: c.Bool("debug"), Color: viper.GetBool("color"), DateFormat: viper.GetString("shortdateformat"), DateTimeFormat: viper.GetString("shortdatetimeformat")}
+		config := &todoist.Config{AccessToken: viper.GetString("token"), DebugMode: c.Bool("debug"), Color: viper.GetBool("color"), DateFormat: viper.GetString("shortdateformat"), DateTimeFormat: viper.GetString("shortdatetimeformat"), BaseURL: viper.GetString("api_url")}
 
 		client := todoist.NewClient(config)
 		client.Store = &store

--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func main() {
 				panic(fmt.Errorf("Config file has wrong permissions. Make sure to give permissions 600 to file %s \n", configFile))
 			}
 		}
-		config := &todoist.Config{AccessToken: viper.GetString("token"), DebugMode: c.Bool("debug"), Color: viper.GetBool("color"), DateFormat: viper.GetString("shortdateformat"), DateTimeFormat: viper.GetString("shortdatetimeformat"), BaseURL: viper.GetString("api_url")}
+		config := &todoist.Config{AccessToken: viper.GetString("token"), DebugMode: c.Bool("debug"), Color: viper.GetBool("color"), DateFormat: viper.GetString("shortdateformat"), DateTimeFormat: viper.GetString("shortdatetimeformat"), APIURL: viper.GetString("api_url")}
 
 		client := todoist.NewClient(config)
 		client.Store = &store


### PR DESCRIPTION
Closes #290

## Changes

- Added `BaseURL` field to `Config` struct in `lib/todoist.go`
- Added `baseURL()` helper on `Client` that falls back to the hardcoded `Server` constant when `BaseURL` is not set
- Both `doApi` and `doRestApi` now use `c.baseURL()` instead of `Server` directly
- Reads `api_url` from config/env in `main.go` and passes it to `Config`

## Usage

In `~/.config/todoist/config.json`:
```json
{
  "token": "your-token",
  "api_url": "https://your-proxy.example.com/api/v1/"
}
```

Or via environment variable:
```bash
TODOIST_API_URL=https://your-proxy.example.com/api/v1/ todoist list
```

No change in behavior when `api_url` is not set.