### PR TITLE
Add sections support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ For more information, see the [official Todoist API announcement](https://groups
 
 ---
 
+## Sections support (BETA)
+
+The `sections` command is now available for managing Todoist sections. This feature is in **BETA** — please report any issues.
+
+```
+$ todoist sections --help
+```
+
+Subcommands: `list`, `add`, `delete`, `archive`, `unarchive`, `update`, `move`, `reorder`
+
+You can also assign tasks to sections using the `--section-name` or `--section-id` flags on the `add` and `modify` commands.
+
+---
+
 ## Description
 
 [Todoist](https://todoist.com/) is a cool TODO list web application.

--- a/add.go
+++ b/add.go
@@ -51,7 +51,7 @@ func Add(c *cli.Context) error {
 
 	sectionName := c.String("section-name")
 	if sectionName != "" {
-		sectionID := client.Store.Sections.GetIDByName(sectionName)
+		sectionID := client.Store.Sections.GetIDByName(sectionName, item.ProjectID)
 		if sectionID == "" {
 			return fmt.Errorf("Did not find a section named '%v'", sectionName)
 		}

--- a/add.go
+++ b/add.go
@@ -49,6 +49,17 @@ func Add(c *cli.Context) error {
 		item.LabelNames = names
 	}
 
+	sectionName := c.String("section-name")
+	if sectionName != "" {
+		sectionID := client.Store.Sections.GetIDByName(sectionName)
+		if sectionID == "" {
+			return fmt.Errorf("Did not find a section named '%v'", sectionName)
+		}
+		item.SectionID = sectionID
+	} else if c.String("section-id") != "" {
+		item.SectionID = c.String("section-id")
+	}
+
 	item.Due = &todoist.Due{String: c.String("date")}
 
 	item.AutoReminder = c.Bool("reminder")

--- a/add_section.go
+++ b/add_section.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	todoist "github.com/sachaos/todoist/lib"
+	"github.com/urfave/cli/v2"
+)
+
+func AddSection(c *cli.Context) error {
+	client := GetClient(c)
+
+	section := todoist.Section{}
+	if !c.Args().Present() {
+		return CommandFailed
+	}
+
+	section.Name = c.Args().First()
+
+	projectName := c.String("project-name")
+	if projectName != "" {
+		projectID := client.Store.Projects.GetIDByName(projectName)
+		if projectID == "" {
+			return fmt.Errorf("Did not find a project named '%v'", projectName)
+		}
+		section.ProjectID = projectID
+	} else {
+		section.ProjectID = c.String("project-id")
+	}
+
+	if err := client.AddSection(context.Background(), section); err != nil {
+		return err
+	}
+
+	return Sync(c)
+}

--- a/add_section.go
+++ b/add_section.go
@@ -29,6 +29,10 @@ func AddSection(c *cli.Context) error {
 		section.ProjectID = c.String("project-id")
 	}
 
+	if section.ProjectID == "" {
+		return fmt.Errorf("project is required: use --project-name or --project-id (note: flags must come before the section name)")
+	}
+
 	if err := client.AddSection(context.Background(), section); err != nil {
 		return err
 	}

--- a/archive_section.go
+++ b/archive_section.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v2"
+)
+
+func ArchiveSection(c *cli.Context) error {
+	client := GetClient(c)
+
+	if !c.Args().Present() {
+		return CommandFailed
+	}
+
+	sectionID := c.Args().First()
+	if client.Store.FindSection(sectionID) == nil {
+		return IdNotFound
+	}
+
+	if err := client.ArchiveSection(context.Background(), sectionID); err != nil {
+		return err
+	}
+
+	return Sync(c)
+}

--- a/delete_section.go
+++ b/delete_section.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v2"
+)
+
+func DeleteSection(c *cli.Context) error {
+	client := GetClient(c)
+
+	if !c.Args().Present() {
+		return CommandFailed
+	}
+
+	sectionID := c.Args().First()
+	if client.Store.FindSection(sectionID) == nil {
+		return IdNotFound
+	}
+
+	if err := client.DeleteSection(context.Background(), sectionID); err != nil {
+		return err
+	}
+
+	return Sync(c)
+}

--- a/lib/item.go
+++ b/lib/item.go
@@ -170,6 +170,9 @@ func (item Item) AddParam() interface{} {
 	if item.Due != nil {
 		param["due"] = item.Due
 	}
+	if item.SectionID != "" {
+		param["section_id"] = item.SectionID
+	}
 	param["auto_reminder"] = item.AutoReminder
 
 	return param
@@ -252,6 +255,20 @@ func (c *Client) DeleteItem(ctx context.Context, ids []string) error {
 func (c *Client) MoveItem(ctx context.Context, item *Item, projectId string) error {
 	commands := Commands{
 		NewCommand("item_move", item.MoveParam(projectId)),
+	}
+	return c.ExecCommands(ctx, commands)
+}
+
+func (item *Item) MoveToSectionParam(sectionId string) interface{} {
+	return map[string]interface{}{
+		"id":         item.ID,
+		"section_id": sectionId,
+	}
+}
+
+func (c *Client) MoveItemToSection(ctx context.Context, item *Item, sectionId string) error {
+	commands := Commands{
+		NewCommand("item_move", item.MoveToSectionParam(sectionId)),
 	}
 	return c.ExecCommands(ctx, commands)
 }

--- a/lib/item_test.go
+++ b/lib/item_test.go
@@ -4,6 +4,60 @@ import (
 	"testing"
 )
 
+func TestItem_AddParam_WithSectionID(t *testing.T) {
+	item := Item{
+		BaseItem: BaseItem{
+			HaveProjectID: HaveProjectID{ProjectID: "proj-1"},
+			Content:       "Test task",
+		},
+		HaveSectionID: HaveSectionID{SectionID: "sec-1"},
+		Priority:      3,
+	}
+	param := item.AddParam().(map[string]interface{})
+
+	if param["content"] != "Test task" {
+		t.Errorf("expected 'Test task', got '%v'", param["content"])
+	}
+	if param["project_id"] != "proj-1" {
+		t.Errorf("expected 'proj-1', got '%v'", param["project_id"])
+	}
+	if param["section_id"] != "sec-1" {
+		t.Errorf("expected 'sec-1', got '%v'", param["section_id"])
+	}
+	if param["priority"] != 3 {
+		t.Errorf("expected 3, got '%v'", param["priority"])
+	}
+}
+
+func TestItem_AddParam_WithoutSectionID(t *testing.T) {
+	item := Item{
+		BaseItem: BaseItem{
+			Content: "Test task",
+		},
+	}
+	param := item.AddParam().(map[string]interface{})
+
+	if _, ok := param["section_id"]; ok {
+		t.Error("expected section_id to be absent when empty")
+	}
+}
+
+func TestItem_MoveToSectionParam(t *testing.T) {
+	item := &Item{
+		BaseItem: BaseItem{
+			HaveID: HaveID{ID: "item-123"},
+		},
+	}
+	param := item.MoveToSectionParam("sec-456").(map[string]interface{})
+
+	if param["id"] != "item-123" {
+		t.Errorf("expected 'item-123', got '%v'", param["id"])
+	}
+	if param["section_id"] != "sec-456" {
+		t.Errorf("expected 'sec-456', got '%v'", param["section_id"])
+	}
+}
+
 func TestItem_LabelsString(t *testing.T) {
 	item1 := Item{
 		LabelNames: []string{"important", "work", "unknown_label"},

--- a/lib/section.go
+++ b/lib/section.go
@@ -1,5 +1,7 @@
 package todoist
 
+import "context"
+
 type Section struct {
 	HaveID
 	HaveProjectID
@@ -11,3 +13,80 @@ type Section struct {
 }
 
 type Sections []Section
+
+func (a Sections) GetIDByName(name string) string {
+	for _, s := range a {
+		if s.Name == name {
+			return s.GetID()
+		}
+	}
+	return ""
+}
+
+func (section Section) AddParam() interface{} {
+	param := map[string]interface{}{}
+	if section.Name != "" {
+		param["name"] = section.Name
+	}
+	if section.ProjectID != "" {
+		param["project_id"] = section.ProjectID
+	}
+	return param
+}
+
+func (c *Client) AddSection(ctx context.Context, section Section) error {
+	commands := Commands{
+		NewCommand("section_add", section.AddParam()),
+	}
+	return c.ExecCommands(ctx, commands)
+}
+
+func (c *Client) DeleteSection(ctx context.Context, id string) error {
+	commands := Commands{
+		NewCommand("section_delete", map[string]interface{}{"id": id}),
+	}
+	return c.ExecCommands(ctx, commands)
+}
+
+func (c *Client) ArchiveSection(ctx context.Context, id string) error {
+	commands := Commands{
+		NewCommand("section_archive", map[string]interface{}{"id": id}),
+	}
+	return c.ExecCommands(ctx, commands)
+}
+
+func (c *Client) UnarchiveSection(ctx context.Context, id string) error {
+	commands := Commands{
+		NewCommand("section_unarchive", map[string]interface{}{"id": id}),
+	}
+	return c.ExecCommands(ctx, commands)
+}
+
+func (c *Client) UpdateSection(ctx context.Context, id string, name string) error {
+	commands := Commands{
+		NewCommand("section_update", map[string]interface{}{"id": id, "name": name}),
+	}
+	return c.ExecCommands(ctx, commands)
+}
+
+func (c *Client) MoveSection(ctx context.Context, sectionID string, projectID string) error {
+	commands := Commands{
+		NewCommand("section_move", map[string]interface{}{"id": sectionID, "project_id": projectID}),
+	}
+	return c.ExecCommands(ctx, commands)
+}
+
+func (c *Client) ReorderSections(ctx context.Context, ids []string) error {
+	type sectionOrder struct {
+		ID           string `json:"id"`
+		SectionOrder int    `json:"section_order"`
+	}
+	sections := make([]sectionOrder, len(ids))
+	for i, id := range ids {
+		sections[i] = sectionOrder{ID: id, SectionOrder: i + 1}
+	}
+	commands := Commands{
+		NewCommand("section_reorder", map[string]interface{}{"sections": sections}),
+	}
+	return c.ExecCommands(ctx, commands)
+}

--- a/lib/section.go
+++ b/lib/section.go
@@ -24,9 +24,9 @@ func (a Sections) Active() Sections {
 	return result
 }
 
-func (a Sections) GetIDByName(name string) string {
-	for _, s := range a {
-		if s.Name == name {
+func (a Sections) GetIDByName(name, projectID string) string {
+	for _, s := range a.Active() {
+		if s.Name == name && (projectID == "" || s.ProjectID == projectID) {
 			return s.GetID()
 		}
 	}

--- a/lib/section.go
+++ b/lib/section.go
@@ -14,6 +14,16 @@ type Section struct {
 
 type Sections []Section
 
+func (a Sections) Active() Sections {
+	result := Sections{}
+	for _, s := range a {
+		if !s.IsDeleted && !s.IsArchived {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
 func (a Sections) GetIDByName(name string) string {
 	for _, s := range a {
 		if s.Name == name {

--- a/lib/section_test.go
+++ b/lib/section_test.go
@@ -1,0 +1,115 @@
+package todoist
+
+import (
+	"testing"
+)
+
+func TestSections_GetIDByName(t *testing.T) {
+	sections := Sections{
+		Section{
+			HaveID:        HaveID{ID: "100"},
+			HaveProjectID: HaveProjectID{ProjectID: "1"},
+			Name:          "Backlog",
+		},
+		Section{
+			HaveID:        HaveID{ID: "200"},
+			HaveProjectID: HaveProjectID{ProjectID: "1"},
+			Name:          "In Progress",
+		},
+		Section{
+			HaveID:        HaveID{ID: "300"},
+			HaveProjectID: HaveProjectID{ProjectID: "2"},
+			Name:          "Done",
+		},
+	}
+
+	// Found
+	if id := sections.GetIDByName("Backlog"); id != "100" {
+		t.Errorf("expected '100', got '%s'", id)
+	}
+	if id := sections.GetIDByName("In Progress"); id != "200" {
+		t.Errorf("expected '200', got '%s'", id)
+	}
+	if id := sections.GetIDByName("Done"); id != "300" {
+		t.Errorf("expected '300', got '%s'", id)
+	}
+
+	// Not found
+	if id := sections.GetIDByName("Nonexistent"); id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+
+	// Empty sections
+	empty := Sections{}
+	if id := empty.GetIDByName("Backlog"); id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+}
+
+func TestSection_AddParam(t *testing.T) {
+	// Both name and project ID
+	section := Section{
+		HaveProjectID: HaveProjectID{ProjectID: "proj-1"},
+		Name:          "My Section",
+	}
+	param := section.AddParam().(map[string]interface{})
+	if param["name"] != "My Section" {
+		t.Errorf("expected 'My Section', got '%v'", param["name"])
+	}
+	if param["project_id"] != "proj-1" {
+		t.Errorf("expected 'proj-1', got '%v'", param["project_id"])
+	}
+
+	// Name only, no project ID
+	section2 := Section{
+		Name: "Another Section",
+	}
+	param2 := section2.AddParam().(map[string]interface{})
+	if param2["name"] != "Another Section" {
+		t.Errorf("expected 'Another Section', got '%v'", param2["name"])
+	}
+	if _, ok := param2["project_id"]; ok {
+		t.Error("expected project_id to be absent")
+	}
+
+	// Empty section
+	section3 := Section{}
+	param3 := section3.AddParam().(map[string]interface{})
+	if len(param3) != 0 {
+		t.Errorf("expected empty param, got %v", param3)
+	}
+}
+
+func TestStore_FindSection(t *testing.T) {
+	store := Store{
+		Sections: Sections{
+			Section{HaveID: HaveID{ID: "s1"}, Name: "Section 1"},
+			Section{HaveID: HaveID{ID: "s2"}, Name: "Section 2"},
+		},
+	}
+	store.SectionMap = map[string]*Section{}
+	for i := range store.Sections {
+		store.SectionMap[store.Sections[i].ID] = &store.Sections[i]
+	}
+
+	found := store.FindSection("s1")
+	if found == nil {
+		t.Fatal("expected to find section s1")
+	}
+	if found.Name != "Section 1" {
+		t.Errorf("expected 'Section 1', got '%s'", found.Name)
+	}
+
+	found2 := store.FindSection("s2")
+	if found2 == nil {
+		t.Fatal("expected to find section s2")
+	}
+	if found2.Name != "Section 2" {
+		t.Errorf("expected 'Section 2', got '%s'", found2.Name)
+	}
+
+	notFound := store.FindSection("nonexistent")
+	if notFound != nil {
+		t.Error("expected nil for nonexistent section")
+	}
+}

--- a/lib/section_test.go
+++ b/lib/section_test.go
@@ -4,6 +4,23 @@ import (
 	"testing"
 )
 
+func TestSections_Active(t *testing.T) {
+	sections := Sections{
+		Section{HaveID: HaveID{ID: "1"}, Name: "Active"},
+		Section{HaveID: HaveID{ID: "2"}, Name: "Deleted", IsDeleted: true},
+		Section{HaveID: HaveID{ID: "3"}, Name: "Archived", IsArchived: true},
+		Section{HaveID: HaveID{ID: "4"}, Name: "Also Active"},
+	}
+
+	active := sections.Active()
+	if len(active) != 2 {
+		t.Fatalf("expected 2 active sections, got %d", len(active))
+	}
+	if active[0].ID != "1" || active[1].ID != "4" {
+		t.Errorf("unexpected active sections: %v", active)
+	}
+}
+
 func TestSections_GetIDByName(t *testing.T) {
 	sections := Sections{
 		Section{

--- a/lib/section_test.go
+++ b/lib/section_test.go
@@ -36,29 +36,51 @@ func TestSections_GetIDByName(t *testing.T) {
 		Section{
 			HaveID:        HaveID{ID: "300"},
 			HaveProjectID: HaveProjectID{ProjectID: "2"},
-			Name:          "Done",
+			Name:          "Backlog",
+		},
+		Section{
+			HaveID:        HaveID{ID: "400"},
+			HaveProjectID: HaveProjectID{ProjectID: "2"},
+			Name:          "Archived Backlog",
+			IsArchived:    true,
+		},
+		Section{
+			HaveID:        HaveID{ID: "500"},
+			HaveProjectID: HaveProjectID{ProjectID: "2"},
+			Name:          "Deleted Backlog",
+			IsDeleted:     true,
 		},
 	}
 
-	// Found
-	if id := sections.GetIDByName("Backlog"); id != "100" {
+	// Project-scoped lookup returns the correct section
+	if id := sections.GetIDByName("Backlog", "1"); id != "100" {
 		t.Errorf("expected '100', got '%s'", id)
 	}
-	if id := sections.GetIDByName("In Progress"); id != "200" {
-		t.Errorf("expected '200', got '%s'", id)
-	}
-	if id := sections.GetIDByName("Done"); id != "300" {
+	if id := sections.GetIDByName("Backlog", "2"); id != "300" {
 		t.Errorf("expected '300', got '%s'", id)
 	}
 
+	// Global lookup (no project) returns first match
+	if id := sections.GetIDByName("In Progress", ""); id != "200" {
+		t.Errorf("expected '200', got '%s'", id)
+	}
+
+	// Archived and deleted sections are never returned
+	if id := sections.GetIDByName("Archived Backlog", ""); id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+	if id := sections.GetIDByName("Deleted Backlog", ""); id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+
 	// Not found
-	if id := sections.GetIDByName("Nonexistent"); id != "" {
+	if id := sections.GetIDByName("Nonexistent", ""); id != "" {
 		t.Errorf("expected '', got '%s'", id)
 	}
 
 	// Empty sections
 	empty := Sections{}
-	if id := empty.GetIDByName("Backlog"); id != "" {
+	if id := empty.GetIDByName("Backlog", ""); id != "" {
 		t.Errorf("expected '', got '%s'", id)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -111,6 +111,14 @@ func main() {
 		Aliases: []string{"r"},
 		Usage:   "set reminder (only premium users)",
 	}
+	sectionIDFlag := cli.StringFlag{
+		Name:  "section-id",
+		Usage: "section id",
+	}
+	sectionNameFlag := cli.StringFlag{
+		Name:  "section-name",
+		Usage: "section name",
+	}
 
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
@@ -290,6 +298,8 @@ func main() {
 				&labelNamesFlag,
 				&projectIDFlag,
 				&projectNameFlag,
+				&sectionIDFlag,
+				&sectionNameFlag,
 				&dateFlag,
 				&reminderFlg,
 			},
@@ -306,6 +316,8 @@ func main() {
 				&labelNamesFlag,
 				&projectIDFlag,
 				&projectNameFlag,
+				&sectionIDFlag,
+				&sectionNameFlag,
 				&dateFlag,
 			},
 			ArgsUsage: "<Item ID>",
@@ -352,6 +364,76 @@ func main() {
 				},
 			},
 			ArgsUsage: "<Project name>",
+		},
+		{
+			Name:      "sections",
+			Usage:     "Manage sections",
+			Action:    Sections,
+			ArgsUsage: " ",
+			Subcommands: []*cli.Command{
+				{
+					Name:   "list",
+					Usage:  "Show all sections",
+					Action: Sections,
+					ArgsUsage: " ",
+				},
+				{
+					Name:   "add",
+					Usage:  "Add new section",
+					Action: AddSection,
+					Flags: []cli.Flag{
+						&projectIDFlag,
+						&projectNameFlag,
+					},
+					ArgsUsage: "<Section name>",
+				},
+				{
+					Name:      "delete",
+					Usage:     "Delete a section",
+					Action:    DeleteSection,
+					ArgsUsage: "<Section ID>",
+				},
+				{
+					Name:      "archive",
+					Usage:     "Archive a section",
+					Action:    ArchiveSection,
+					ArgsUsage: "<Section ID>",
+				},
+				{
+					Name:      "unarchive",
+					Usage:     "Unarchive a section",
+					Action:    UnarchiveSection,
+					ArgsUsage: "<Section ID>",
+				},
+				{
+					Name:   "update",
+					Usage:  "Update section name",
+					Action: UpdateSection,
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "name",
+							Usage: "new section name",
+						},
+					},
+					ArgsUsage: "<Section ID>",
+				},
+				{
+					Name:   "move",
+					Usage:  "Move section to another project",
+					Action: MoveSection,
+					Flags: []cli.Flag{
+						&projectIDFlag,
+						&projectNameFlag,
+					},
+					ArgsUsage: "<Section ID>",
+				},
+				{
+					Name:      "reorder",
+					Usage:     "Reorder sections within a project",
+					Action:    ReorderSections,
+					ArgsUsage: "<Section ID> <Section ID> ...",
+				},
+			},
 		},
 		{
 			Name:      "karma",

--- a/main.go
+++ b/main.go
@@ -429,9 +429,10 @@ func main() {
 				},
 				{
 					Name:      "reorder",
-					Usage:     "Reorder sections within a project",
+					Usage:     "Reorder sections by specifying section IDs in the desired order",
 					Action:    ReorderSections,
 					ArgsUsage: "<Section ID> <Section ID> ...",
+					Description: "Reorder sections within a project. The sections will be arranged in the\norder you specify. Requires at least 2 section IDs.\n\nExample: todoist sections reorder <id1> <id2> <id3>",
 				},
 			},
 		},

--- a/modify.go
+++ b/modify.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/sachaos/todoist/lib"
@@ -42,6 +43,15 @@ func Modify(c *cli.Context) error {
 		projectID = client.Store.Projects.GetIDByName(c.String("project-name"))
 	}
 
+	sectionName := c.String("section-name")
+	sectionID := c.String("section-id")
+	if sectionName != "" {
+		sectionID = client.Store.Sections.GetIDByName(sectionName)
+		if sectionID == "" {
+			return fmt.Errorf("Did not find a section named '%v'", sectionName)
+		}
+	}
+
 	if !c.Args().Present() {
 		return CommandFailed
 	}
@@ -52,6 +62,12 @@ func Modify(c *cli.Context) error {
 
 	if projectID != "" {
 		if err := client.MoveItem(context.Background(), item, projectID); err != nil {
+			return err
+		}
+	}
+
+	if sectionID != "" {
+		if err := client.MoveItemToSection(context.Background(), item, sectionID); err != nil {
 			return err
 		}
 	}

--- a/modify.go
+++ b/modify.go
@@ -52,10 +52,6 @@ func Modify(c *cli.Context) error {
 		}
 	}
 
-	if !c.Args().Present() {
-		return CommandFailed
-	}
-
 	if err := client.UpdateItem(context.Background(), *item); err != nil {
 		return err
 	}

--- a/modify.go
+++ b/modify.go
@@ -46,7 +46,7 @@ func Modify(c *cli.Context) error {
 	sectionName := c.String("section-name")
 	sectionID := c.String("section-id")
 	if sectionName != "" {
-		sectionID = client.Store.Sections.GetIDByName(sectionName)
+		sectionID = client.Store.Sections.GetIDByName(sectionName, projectID)
 		if sectionID == "" {
 			return fmt.Errorf("Did not find a section named '%v'", sectionName)
 		}

--- a/move_section.go
+++ b/move_section.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+func MoveSection(c *cli.Context) error {
+	client := GetClient(c)
+
+	if !c.Args().Present() {
+		return CommandFailed
+	}
+
+	sectionID := c.Args().First()
+	if client.Store.FindSection(sectionID) == nil {
+		return IdNotFound
+	}
+
+	projectName := c.String("project-name")
+	projectID := c.String("project-id")
+	if projectName != "" {
+		projectID = client.Store.Projects.GetIDByName(projectName)
+		if projectID == "" {
+			return fmt.Errorf("Did not find a project named '%v'", projectName)
+		}
+	}
+
+	if projectID == "" {
+		return fmt.Errorf("--project-id or --project-name flag is required")
+	}
+
+	if err := client.MoveSection(context.Background(), sectionID, projectID); err != nil {
+		return err
+	}
+
+	return Sync(c)
+}

--- a/reorder_sections.go
+++ b/reorder_sections.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+func ReorderSections(c *cli.Context) error {
+	client := GetClient(c)
+
+	if c.Args().Len() < 2 {
+		return fmt.Errorf("reorder-sections requires at least 2 section IDs")
+	}
+
+	ids := c.Args().Slice()
+	for _, id := range ids {
+		if client.Store.FindSection(id) == nil {
+			return fmt.Errorf("section id not found: %s", id)
+		}
+	}
+
+	if err := client.ReorderSections(context.Background(), ids); err != nil {
+		return err
+	}
+
+	return Sync(c)
+}

--- a/reorder_sections.go
+++ b/reorder_sections.go
@@ -11,7 +11,7 @@ func ReorderSections(c *cli.Context) error {
 	client := GetClient(c)
 
 	if c.Args().Len() < 2 {
-		return fmt.Errorf("reorder-sections requires at least 2 section IDs")
+		return fmt.Errorf("sections reorder requires at least 2 section IDs")
 	}
 
 	ids := c.Args().Slice()

--- a/sections.go
+++ b/sections.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+func Sections(c *cli.Context) error {
+	client := GetClient(c)
+
+	defer writer.Flush()
+
+	if c.Bool("header") {
+		writer.Write([]string{"ID", "Project", "Name"})
+	}
+
+	for _, section := range client.Store.Sections {
+		project := client.Store.FindProject(section.ProjectID)
+		projectName := ""
+		if project != nil {
+			projectName = project.Name
+		}
+		writer.Write([]string{IdFormat(section), projectName, section.Name})
+	}
+
+	return nil
+}

--- a/sections.go
+++ b/sections.go
@@ -13,7 +13,7 @@ func Sections(c *cli.Context) error {
 		writer.Write([]string{"ID", "Project", "Name"})
 	}
 
-	for _, section := range client.Store.Sections {
+	for _, section := range client.Store.Sections.Active() {
 		project := client.Store.FindProject(section.ProjectID)
 		projectName := ""
 		if project != nil {

--- a/show.go
+++ b/show.go
@@ -29,6 +29,7 @@ func Show(c *cli.Context) error {
 		[]string{"ID", IdFormat(item)},
 		[]string{"Content", ContentFormat(item)},
 		[]string{"Project", ProjectFormat(item.ProjectID, client.Store, projectColorHash, c)},
+		[]string{"Section", SectionFormat(item.SectionID, client.Store, c)},
 		[]string{"Labels", item.LabelsString()},
 		[]string{"Priority", PriorityFormat(item.Priority)},
 		[]string{"DueDate", DueDateFormat(item.DateTime(), item.AllDay)},

--- a/show.go
+++ b/show.go
@@ -11,9 +11,15 @@ import (
 func Show(c *cli.Context) error {
 	client := GetClient(c)
 
-	item_id := c.Args().First()
+	id := c.Args().First()
 
-	item := client.Store.FindItem(item_id)
+	// Check if the ID refers to a section
+	section := client.Store.FindSection(id)
+	if section != nil {
+		return showSection(c, client, section)
+	}
+
+	item := client.Store.FindItem(id)
 	if item == nil {
 		return IdNotFound
 	}
@@ -47,6 +53,27 @@ func Show(c *cli.Context) error {
 				browser.OpenURL(url)
 			}
 		}
+	}
+	return nil
+}
+
+func showSection(c *cli.Context, client *todoist.Client, section *todoist.Section) error {
+	colorList := ColorList()
+	var projectIds []string
+	for _, project := range client.Store.Projects {
+		projectIds = append(projectIds, project.GetID())
+	}
+	projectColorHash := GenerateColorHash(projectIds, colorList)
+
+	records := [][]string{
+		{"ID", IdFormat(section)},
+		{"Name", section.Name},
+		{"Project", ProjectFormat(section.ProjectID, client.Store, projectColorHash, c)},
+	}
+	defer writer.Flush()
+
+	for _, record := range records {
+		writer.Write(record)
 	}
 	return nil
 }

--- a/show_test.go
+++ b/show_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"testing"
+
+	"github.com/fatih/color"
+	todoist "github.com/sachaos/todoist/lib"
+	"github.com/urfave/cli/v2"
+)
+
+func newTestContext(client *todoist.Client, args []string) *cli.Context {
+	app := cli.NewApp()
+	app.Metadata = map[string]interface{}{
+		"client": client,
+	}
+
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.Bool("browse", false, "")
+	flagSet.Bool("header", false, "")
+	flagSet.Bool("color", false, "")
+	flagSet.Bool("project-namespace", false, "")
+	flagSet.Bool("indent", false, "")
+	flagSet.Parse(args)
+
+	ctx := cli.NewContext(app, flagSet, nil)
+	return ctx
+}
+
+func testStore() *todoist.Store {
+	store := &todoist.Store{
+		Projects: todoist.Projects{
+			{HaveID: todoist.HaveID{ID: "proj-1"}, Name: "Work"},
+		},
+		Sections: todoist.Sections{
+			{
+				HaveID:        todoist.HaveID{ID: "sec-1"},
+				HaveProjectID: todoist.HaveProjectID{ProjectID: "proj-1"},
+				Name:          "Backlog",
+			},
+		},
+		Items: todoist.Items{
+			{
+				BaseItem: todoist.BaseItem{
+					HaveID:        todoist.HaveID{ID: "item-1"},
+					HaveProjectID: todoist.HaveProjectID{ProjectID: "proj-1"},
+					Content:       "Test task",
+				},
+				HaveSectionID: todoist.HaveSectionID{SectionID: "sec-1"},
+				Priority:      3,
+			},
+		},
+	}
+	store.ConstructItemTree()
+	return store
+}
+
+func TestShow_Item(t *testing.T) {
+	color.NoColor = true
+
+	store := testStore()
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = store
+
+	ctx := newTestContext(client, []string{"item-1"})
+
+	var buf bytes.Buffer
+	writer = NewTSVWriter(&buf)
+
+	err := Show(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	output := buf.String()
+	if !bytes.Contains([]byte(output), []byte("item-1")) {
+		t.Errorf("expected output to contain item ID, got: %s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("Test task")) {
+		t.Errorf("expected output to contain item content, got: %s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("Backlog")) {
+		t.Errorf("expected output to contain section name, got: %s", output)
+	}
+}
+
+func TestShow_Section(t *testing.T) {
+	color.NoColor = true
+
+	store := testStore()
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = store
+
+	ctx := newTestContext(client, []string{"sec-1"})
+
+	var buf bytes.Buffer
+	writer = NewTSVWriter(&buf)
+
+	err := Show(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	output := buf.String()
+	if !bytes.Contains([]byte(output), []byte("sec-1")) {
+		t.Errorf("expected output to contain section ID, got: %s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("Backlog")) {
+		t.Errorf("expected output to contain section name, got: %s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("Work")) {
+		t.Errorf("expected output to contain project name, got: %s", output)
+	}
+}
+
+func TestShow_NotFound(t *testing.T) {
+	color.NoColor = true
+
+	store := testStore()
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = store
+
+	ctx := newTestContext(client, []string{"nonexistent"})
+
+	var buf bytes.Buffer
+	writer = NewTSVWriter(&buf)
+
+	err := Show(ctx)
+	if err != IdNotFound {
+		t.Errorf("expected IdNotFound error, got %v", err)
+	}
+}

--- a/unarchive_section.go
+++ b/unarchive_section.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v2"
+)
+
+func UnarchiveSection(c *cli.Context) error {
+	client := GetClient(c)
+
+	if !c.Args().Present() {
+		return CommandFailed
+	}
+
+	sectionID := c.Args().First()
+	if client.Store.FindSection(sectionID) == nil {
+		return IdNotFound
+	}
+
+	if err := client.UnarchiveSection(context.Background(), sectionID); err != nil {
+		return err
+	}
+
+	return Sync(c)
+}

--- a/unarchive_section.go
+++ b/unarchive_section.go
@@ -14,10 +14,8 @@ func UnarchiveSection(c *cli.Context) error {
 	}
 
 	sectionID := c.Args().First()
-	if client.Store.FindSection(sectionID) == nil {
-		return IdNotFound
-	}
 
+	// Don't validate against local cache - archived sections aren't cached locally
 	if err := client.UnarchiveSection(context.Background(), sectionID); err != nil {
 		return err
 	}

--- a/update_section.go
+++ b/update_section.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+func UpdateSection(c *cli.Context) error {
+	client := GetClient(c)
+
+	if !c.Args().Present() {
+		return CommandFailed
+	}
+
+	sectionID := c.Args().First()
+	if client.Store.FindSection(sectionID) == nil {
+		return IdNotFound
+	}
+
+	name := c.String("name")
+	if name == "" {
+		return fmt.Errorf("--name flag is required")
+	}
+
+	if err := client.UpdateSection(context.Background(), sectionID, name); err != nil {
+		return err
+	}
+
+	return Sync(c)
+}


### PR DESCRIPTION
## Summary

- Add `todoist sections` command with subcommands: `list`, `add`, `delete`, `archive`, `unarchive`, `update`, `move`, `reorder`
- Add `--section-id` / `--section-name` flags to `todoist add` and `todoist modify` for assigning tasks to sections
- Display section in `todoist show` output

Closes #274

## Test plan

- [x] `todoist sections` lists all sections with project names
- [ ] `todoist sections add "Name" --project-name "Project"` creates a section
- [ ] `todoist add "Task" --section-name "Name"` adds a task to a section
- [ ] `todoist modify <ID> --section-name "Name"` moves a task to a section
- [x] `todoist show <ID>` displays the section row
- [x] `todoist sections delete` works as expected
- [x] `todoist sections archive` works as expected
- [x] `todoist sections unarchive` works as expected
- [ ] `todoist sections move` works as expected
- [ ] `todoist sections reorder` works as expected
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)