### PR TITLE
Fix help command prompting for API key (#296)

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,20 @@ func GetClient(c *cli.Context) *todoist.Client {
 	return c.App.Metadata["client"].(*todoist.Client)
 }
 
+// isHelpCommand returns true if the given arguments represent a help invocation
+// that should skip authentication and config setup.
+func isHelpCommand(cliArgs []string, osArgs []string) bool {
+	if len(cliArgs) == 0 || cliArgs[0] == "help" || cliArgs[0] == "h" {
+		return true
+	}
+	for _, a := range osArgs {
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "todoist"
@@ -130,6 +144,11 @@ func main() {
 	}
 
 	app.Before = func(c *cli.Context) error {
+		// Skip auth/config setup for help commands
+		if isHelpCommand(c.Args().Slice(), os.Args) {
+			return nil
+		}
+
 		var store todoist.Store
 
 		if err := LoadCache(cachePath, &store); err != nil {

--- a/main.go
+++ b/main.go
@@ -173,20 +173,22 @@ func main() {
 			if _, isConfigNotFoundError := err.(viper.ConfigFileNotFoundError); !isConfigNotFoundError {
 				// config file was found but could not be read => not recoverable
 				return err
-			} else if !viper.IsSet("token") {
-				// config file not found and token missing (not provided via another source,
-				// such as environment variables) => ask interactively for token and store it in config file.
-				fmt.Printf("Input API Token: ")
-				fmt.Scan(&token)
-				viper.Set("token", token)
-				buf, err := json.MarshalIndent(viper.AllSettings(), "", "  ")
-				if err != nil {
-					panic(fmt.Errorf("Fatal error config file: %s \n", err))
-				}
-				err = ioutil.WriteFile(configFile, buf, 0600)
-				if err != nil {
-					panic(fmt.Errorf("Fatal error config file: %s \n", err))
-				}
+			}
+		}
+
+		if !viper.IsSet("token") || viper.GetString("token") == "" {
+			// token missing (not provided via config file or environment variables)
+			// => ask interactively for token and store it in config file.
+			fmt.Printf("Input API Token: ")
+			fmt.Scan(&token)
+			viper.Set("token", token)
+			buf, err := json.MarshalIndent(viper.AllSettings(), "", "  ")
+			if err != nil {
+				panic(fmt.Errorf("Fatal error config file: %s \n", err))
+			}
+			err = ioutil.WriteFile(configFile, buf, 0600)
+			if err != nil {
+				panic(fmt.Errorf("Fatal error config file: %s \n", err))
 			}
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsHelpCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		cliArgs  []string
+		osArgs   []string
+		expected bool
+	}{
+		{
+			name:     "no args shows help",
+			cliArgs:  []string{},
+			osArgs:   []string{"todoist"},
+			expected: true,
+		},
+		{
+			name:     "help subcommand",
+			cliArgs:  []string{"help"},
+			osArgs:   []string{"todoist", "help"},
+			expected: true,
+		},
+		{
+			name:     "h alias",
+			cliArgs:  []string{"h"},
+			osArgs:   []string{"todoist", "h"},
+			expected: true,
+		},
+		{
+			name:     "--help flag",
+			cliArgs:  []string{"list"},
+			osArgs:   []string{"todoist", "list", "--help"},
+			expected: true,
+		},
+		{
+			name:     "-h flag",
+			cliArgs:  []string{"list"},
+			osArgs:   []string{"todoist", "list", "-h"},
+			expected: true,
+		},
+		{
+			name:     "top-level --help",
+			cliArgs:  []string{},
+			osArgs:   []string{"todoist", "--help"},
+			expected: true,
+		},
+		{
+			name:     "list command is not help",
+			cliArgs:  []string{"list"},
+			osArgs:   []string{"todoist", "list"},
+			expected: false,
+		},
+		{
+			name:     "add command is not help",
+			cliArgs:  []string{"add", "buy milk"},
+			osArgs:   []string{"todoist", "add", "buy milk"},
+			expected: false,
+		},
+		{
+			name:     "sync command is not help",
+			cliArgs:  []string{"sync"},
+			osArgs:   []string{"todoist", "sync"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isHelpCommand(tt.cliArgs, tt.osArgs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Skip auth/config setup in `app.Before` for help invocations (`help`, `h`, `--help`, `-h`) so users can access help without being prompted for an API key
- Extract `isHelpCommand()` as a standalone testable function
- Add table-driven tests covering all help and non-help argument patterns

Fixes #296

## Test plan
- [x] `make test` passes (all 20 tests including 9 new subtests)
- [x] `make build` succeeds
- [x] Manual: remove API token config, run `todoist help` — should show help without prompting
- [ ] Manual: run `todoist list --help` — should show help without prompting
- [ ] Manual: run `todoist list` without token — should still prompt for token

🤖 Generated with [Claude Code](https://claude.com/claude-code)