### PR TITLE
Fix api v1 robustness

### DIFF
--- a/add.go
+++ b/add.go
@@ -39,14 +39,15 @@ func Add(c *cli.Context) error {
 		item.ProjectID = c.String("project-id")
 	}
 
-	item.LabelNames = func(str string) []string {
-		stringNames := strings.Split(str, ",")
+	labelNames := c.String("label-names")
+	if labelNames != "" {
+		stringNames := strings.Split(labelNames, ",")
 		names := []string{}
 		for _, stringName := range stringNames {
-			names = append(names, stringName)
+			names = append(names, strings.TrimSpace(stringName))
 		}
-		return names
-	}(c.String("label-names"))
+		item.LabelNames = names
+	}
 
 	item.Due = &todoist.Due{String: c.String("date")}
 

--- a/lib/item.go
+++ b/lib/item.go
@@ -164,7 +164,7 @@ func (item Item) AddParam() interface{} {
 	if item.Priority != 0 {
 		param["priority"] = item.Priority
 	}
-	if item.ProjectID != "" {
+	if item.ProjectID != "" && item.ProjectID != "0" {
 		param["project_id"] = item.ProjectID
 	}
 	if item.Due != nil {

--- a/lib/item.go
+++ b/lib/item.go
@@ -164,7 +164,7 @@ func (item Item) AddParam() interface{} {
 	if item.Priority != 0 {
 		param["priority"] = item.Priority
 	}
-	if item.ProjectID != "" && item.ProjectID != "0" {
+	if item.ProjectID != "" {
 		param["project_id"] = item.ProjectID
 	}
 	if item.Due != nil {

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -153,10 +153,6 @@ func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 		return err
 	}
 
-	if c.Store != nil {
-		c.Store.SyncToken = r.SyncToken
-	}
-
 	for _, command := range commands {
 		status, ok := r.SyncStatus[command.UUID]
 		if !ok {

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -3,6 +3,7 @@ package todoist
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -134,14 +135,40 @@ func (c *Client) doRestApi(ctx context.Context, method string, uri string, body 
 }
 
 type ExecResult struct {
-	SyncToken     string      `json:"sync_token"`
-	SyncStatus    interface{} `json:"sync_status"`
-	TempIdMapping interface{} `json:"temp_id_mapping"`
+	SyncToken     string                 `json:"sync_token"`
+	SyncStatus    map[string]interface{} `json:"sync_status"`
+	TempIdMapping interface{}            `json:"temp_id_mapping"`
 }
 
 func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 	var r ExecResult
-	return c.doApi(ctx, http.MethodPost, "sync", commands.UrlValues(), &r)
+	params := commands.UrlValues()
+	if c.Store != nil && c.Store.SyncToken != "" {
+		params.Set("sync_token", c.Store.SyncToken)
+	} else {
+		params.Set("sync_token", "*")
+	}
+
+	if err := c.doApi(ctx, http.MethodPost, "sync", params, &r); err != nil {
+		return err
+	}
+
+	if c.Store != nil {
+		c.Store.SyncToken = r.SyncToken
+	}
+
+	for _, command := range commands {
+		status, ok := r.SyncStatus[command.UUID]
+		if !ok {
+			continue
+		}
+
+		if status != "ok" {
+			return fmt.Errorf("command %s failed: %v", command.Type, status)
+		}
+	}
+
+	return nil
 }
 
 func (c *Client) QuickCommand(ctx context.Context, text string) error {

--- a/main.go
+++ b/main.go
@@ -179,7 +179,10 @@ func main() {
 		if !viper.IsSet("token") || viper.GetString("token") == "" {
 			// token missing (not provided via config file or environment variables)
 			// => ask interactively for token and store it in config file.
-			fmt.Printf("Input API Token: ")
+			fmt.Println("No API token found. A Todoist API token is required for this application.")
+			fmt.Println("You can find your token in the Todoist Settings under Integrations > Developer:")
+			fmt.Printf("%s\n", color.CyanString("https://todoist.com/app/settings/integrations/developer"))
+			fmt.Print("\nTodoist API Token: ")
 			fmt.Scan(&token)
 			viper.Set("token", token)
 			buf, err := json.MarshalIndent(viper.AllSettings(), "", "  ")

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 		Aliases: []string{"L"},
 		Usage:   "label names (separated by ,)",
 	}
-	projectIDFlag := cli.IntFlag{
+	projectIDFlag := cli.StringFlag{
 		Name:    "project-id",
 		Aliases: []string{"P"},
 		Usage:   "project id",

--- a/modify.go
+++ b/modify.go
@@ -50,8 +50,10 @@ func Modify(c *cli.Context) error {
 		return err
 	}
 
-	if err := client.MoveItem(context.Background(), item, projectID); err != nil {
-		return err
+	if projectID != "" && projectID != "0" {
+		if err := client.MoveItem(context.Background(), item, projectID); err != nil {
+			return err
+		}
 	}
 
 	return Sync(c)

--- a/modify.go
+++ b/modify.go
@@ -26,14 +26,14 @@ func Modify(c *cli.Context) error {
 	}
 	item.Content = c.String("content")
 	item.Priority = priorityMapping[c.Int("priority")]
-	item.LabelNames = func(str string) []string {
-		stringNames := strings.Split(str, ",")
+	if labelNames := c.String("label-names"); labelNames != "" {
+		stringNames := strings.Split(labelNames, ",")
 		names := []string{}
 		for _, stringName := range stringNames {
-			names = append(names, stringName)
+			names = append(names, strings.TrimSpace(stringName))
 		}
-		return names
-	}(c.String("label-names"))
+		item.LabelNames = names
+	}
 
 	item.Due = &todoist.Due{String: c.String("date")}
 
@@ -50,7 +50,7 @@ func Modify(c *cli.Context) error {
 		return err
 	}
 
-	if projectID != "" && projectID != "0" {
+	if projectID != "" {
 		if err := client.MoveItem(context.Background(), item, projectID); err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description**

While testing a local build with the recently migrated Sync API v1, I discovered that several commands (like add and modify) were failing silently—returning a successful exit code without actually reflecting changes in Todoist.

After debugging, I identified that the API v1 is stricter regarding input types and requires better handling of the sync_token and command statuses. This PR provides a systemic fix to ensure robust communication with the new API.

**Key Changes**

1. Infrastructure & Error Handling (lib/todoist.go)
 * Validation of `sync_status`: Previously, `ExecCommands` ignored individual command results. It now parses the `sync_status` map and returns an explicit error if a command is rejected by the API.
 * `sync_token` Persistence: Updated `ExecCommands` to include the `sync_token` in every request and update the local Store with the new  token from the response. This prevents state desynchronization.

2. Alphanumeric ID Support (`main.go`)
 * Type Migration: Changed the project-id flag from `IntFlag` to `StringFlag`. This is required to support the new alphanumeric IDs used in API v1 (e.g., 6gGJR...), which previously triggered a "parse error" when passed as integers.

3. Sanitization & API Compatibility (add.go, modify.go, lib/item.go)
 * Empty Labels: Fixed a bug where `strings.Split` on an empty string would send [""] to the API, causing a 400 error. Added `strings.TrimSpace` to clean up user input.
 * Invalid Project IDs: Updated `AddParam` and `Modify` to avoid sending `project_id: "0"` or empty strings. In API v1, "0" is no longer a valid ID for the Inbox; omitting the field allows the API to handle the default placement correctly.
 * Redundant Calls: Wrapped MoveItem in `modify.go` to only execute when a project is actually specified, avoiding unnecessary API errors.

**Testing Performed**

 - Verified todoist add with and without labels/projects.
 - Verified todoist modify using alphanumeric --project-id.
 - Confirmed that errors (like invalid IDs) are now correctly reported to the CLI instead of failing silently.
 - Performed todoist sync to ensure cache integrity with the new token handling.