### PR TITLE
lib/project: filter #name matches exact project, not prefix

### DIFF
--- a/filter_eval_test.go
+++ b/filter_eval_test.go
@@ -92,6 +92,26 @@ func TestProjectEval(t *testing.T) {
 	testFilterEvalWithProject(t, "#hoge", item1, projects, false)
 	testFilterEvalWithProject(t, "#private", item2, projects, false)
 	testFilterEvalWithProject(t, "##private", item2, projects, true)
+
+	// Exact match only — prefix/substring should not match
+	projectsWithSimilarNames := todoist.Projects{
+		todoist.Project{
+			HaveID: todoist.HaveID{ID: "10"},
+			Name:   "Work",
+		},
+		todoist.Project{
+			HaveID: todoist.HaveID{ID: "11"},
+			Name:   "Work Admin",
+		},
+	}
+	itemInWork := todoist.Item{}
+	itemInWork.ProjectID = "10"
+	itemInWorkAdmin := todoist.Item{}
+	itemInWorkAdmin.ProjectID = "11"
+
+	testFilterEvalWithProject(t, "#Work", itemInWork, projectsWithSimilarNames, true)
+	testFilterEvalWithProject(t, "#Work", itemInWorkAdmin, projectsWithSimilarNames, false) // must not match "Work Admin"
+	testFilterEvalWithProject(t, "#WORK", itemInWork, projectsWithSimilarNames, true)       // case-insensitive
 }
 
 func TestBoolInfixOpExp(t *testing.T) {

--- a/lib/project.go
+++ b/lib/project.go
@@ -44,7 +44,7 @@ func (a Projects) GetIDsByName(name string, isAll bool) []string {
 	ids := []string{}
 	name = strings.ToLower(name)
 	for _, pjt := range a {
-		if strings.Contains(strings.ToLower(pjt.Name), name) {
+		if strings.ToLower(pjt.Name) == name {
 			ids = append(ids, pjt.ID)
 			if isAll {
 				parentID := pjt.ID


### PR DESCRIPTION
Closes #304. `#Project A` was matching `Project Apple` because of `strings.Contains`. Use exact case-insensitive match.