### PR TITLE
Add support for task description field

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/add.go
+++ b/add.go
@@ -60,6 +60,8 @@ func Add(c *cli.Context) error {
 		item.SectionID = c.String("section-id")
 	}
 
+	item.Description = c.String("description")
+
 	item.Due = &todoist.Due{String: c.String("date")}
 
 	item.AutoReminder = c.Bool("reminder")

--- a/lib/item.go
+++ b/lib/item.go
@@ -65,6 +65,7 @@ type Item struct {
 	HaveSectionID
 	ChildItem      *Item       `json:"-"`
 	BrotherItem    *Item       `json:"-"`
+	Description    string      `json:"description"`
 	AllDay         bool        `json:"all_day"`
 	AssignedByUID  string      `json:"assigned_by_uid"`
 	Checked        bool        `json:"checked"`
@@ -173,6 +174,9 @@ func (item Item) AddParam() interface{} {
 	if item.SectionID != "" {
 		param["section_id"] = item.SectionID
 	}
+	if item.Description != "" {
+		param["description"] = item.Description
+	}
 	param["auto_reminder"] = item.AutoReminder
 
 	return param
@@ -201,6 +205,9 @@ func (item Item) UpdateParam() interface{} {
 	}
 	if item.Due != nil {
 		param["due"] = item.Due
+	}
+	if item.Description != "" {
+		param["description"] = item.Description
 	}
 	return param
 }

--- a/main.go
+++ b/main.go
@@ -119,6 +119,11 @@ func main() {
 		Name:  "section-name",
 		Usage: "section name",
 	}
+	descriptionFlag := cli.StringFlag{
+		Name:    "description",
+		Aliases: []string{"D"},
+		Usage:   "task description",
+	}
 
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
@@ -302,6 +307,7 @@ func main() {
 				&sectionNameFlag,
 				&dateFlag,
 				&reminderFlg,
+				&descriptionFlag,
 			},
 			ArgsUsage: "<Item content>",
 		},
@@ -319,6 +325,7 @@ func main() {
 				&sectionIDFlag,
 				&sectionNameFlag,
 				&dateFlag,
+				&descriptionFlag,
 			},
 			ArgsUsage: "<Item ID>",
 		},

--- a/modify.go
+++ b/modify.go
@@ -26,6 +26,7 @@ func Modify(c *cli.Context) error {
 		return IdNotFound
 	}
 	item.Content = c.String("content")
+	item.Description = c.String("description")
 	item.Priority = priorityMapping[c.Int("priority")]
 	if labelNames := c.String("label-names"); labelNames != "" {
 		stringNames := strings.Split(labelNames, ",")

--- a/show.go
+++ b/show.go
@@ -34,6 +34,7 @@ func Show(c *cli.Context) error {
 	records := [][]string{
 		[]string{"ID", IdFormat(item)},
 		[]string{"Content", ContentFormat(item)},
+		[]string{"Description", item.Description},
 		[]string{"Project", ProjectFormat(item.ProjectID, client.Store, projectColorHash, c)},
 		[]string{"Section", SectionFormat(item.SectionID, client.Store, c)},
 		[]string{"Labels", item.LabelsString()},


### PR DESCRIPTION
Add support for the [Description](https://www.todoist.com/help/articles/add-a-task-description-in-todoist-rOryWIHn) field on tasks.

## Changes
- Add `Description` field to `Item` struct with `json:"description"` tag
- Include description in `AddParam()` and `UpdateParam()` when non-empty
- Display description in `show` command output
- Add `--description`/`-D` flag to `add` and `modify` commands

Closes https://github.com/sachaos/todoist/issues/306

Generated with [Claude Code](https://claude.ai/code)