### PR TITLE
Add Claude Code workflow skills for feature development

### DIFF
--- a/.claude/commands/todoist-implement.md
+++ b/.claude/commands/todoist-implement.md
@@ -65,4 +65,15 @@ PR body should include:
 
 Invoke the `/code-review:code-review` skill against the new PR number.
 
-Report the PR URL to the user and wait for their manual testing before they call `/todoist-ship`.
+## Step 9 — Prompt for manual testing
+
+Tell the user the PR URL and present a manual test checklist derived from the spec. At minimum include:
+
+- The happy path (valid ID, expected success behavior)
+- The no-args case (should show usage, not a cryptic error)
+- An invalid ID (should surface a clear API error message)
+- Any edge cases called out in the spec (recurring tasks, already-active tasks, etc.)
+
+Then explicitly ask: **"Please run through the test checklist above. When you're done, call `/todoist-ship <PR-number>` to merge."**
+
+Do not proceed further — the skill ends here and waits for the user.

--- a/.claude/commands/todoist-implement.md
+++ b/.claude/commands/todoist-implement.md
@@ -1,0 +1,68 @@
+---
+description: Read a spec issue, implement the feature, open a PR, and run code review.
+model: claude-opus-4-7
+---
+
+You are implementing a feature for the todoist CLI. The spec is in a GitHub issue number provided as the argument.
+
+## Step 1 — Read the spec
+
+Run: `gh issue view <issue-number> --repo sachaos/todoist`
+
+Extract:
+- The command name, args, and flags
+- The API endpoint and HTTP method
+- Behavior details (error handling, success output, sync behavior)
+- Help text to use in `main.go` Description field
+
+## Step 2 — Research existing patterns
+
+Read these files to understand patterns to follow:
+- `close.go` and `lib/item.go` — template for simple mutation commands
+- `main.go` — how commands are registered (structure, flags, ArgsUsage, Description)
+- `lib/todoist.go` — `doRestApi` and `doApi` helpers; note that 204 No Content is handled as success
+
+## Step 3 — Create a branch
+
+`git checkout -b <feature-branch-name>` using a descriptive kebab-case name.
+
+## Step 4 — Spawn implementation agent (Sonnet)
+
+Brief a general-purpose Sonnet agent with:
+- The full spec (paste it verbatim)
+- Specific files to create/modify and what each change should do
+- Patterns to follow from the existing codebase
+- Reminders: do NOT call `Sync(c)` unless the spec says to; do NOT commit or push; do NOT add features beyond the spec
+- After implementing: run `make build` and `make test` and report results
+
+Wait for the agent to complete before proceeding.
+
+## Step 5 — Review and fix
+
+Check the agent's output. If `make build` or `make test` failed, fix the issues directly. Verify the implementation matches the spec.
+
+## Step 6 — Commit and push
+
+```
+git add <changed files>
+git commit -m "<imperative summary>\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+git push -u origin <branch>
+```
+
+## Step 7 — Open the PR
+
+```
+gh pr create --title "..." --body "..."
+```
+
+PR body should include:
+- "Closes #<issue-number>"
+- Summary of changes (files modified and why)
+- Design notes explaining non-obvious decisions (API choice, cache behavior)
+- Test plan checklist (build, tests, manual steps)
+
+## Step 8 — Run code review
+
+Invoke the `/code-review:code-review` skill against the new PR number.
+
+Report the PR URL to the user and wait for their manual testing before they call `/todoist-ship`.

--- a/.claude/commands/todoist-ship.md
+++ b/.claude/commands/todoist-ship.md
@@ -1,0 +1,43 @@
+---
+description: Merge a PR, check off the item on the meta feature-gaps issue, and update memory.
+model: claude-haiku-4-5-20251001
+---
+
+You are closing out a completed feature PR for the todoist CLI. The PR number is provided as the argument.
+
+## Step 1 — Identify the meta-issue
+
+Check your memory for the active meta-issue number. If not found, ask the user before continuing.
+
+## Step 2 — Verify the PR is ready
+
+Run: `gh pr view <PR-number> --repo sachaos/todoist`
+
+Confirm it is open and not a draft. If already merged or closed, report that and stop.
+
+## Step 3 — Merge
+
+```
+gh pr merge <PR-number> --repo sachaos/todoist --squash --delete-branch
+```
+
+## Step 4 — Check off item on the meta-issue
+
+Run: `gh issue view <meta-issue> --repo sachaos/todoist --json body --jq '.body'`
+
+Find the line corresponding to the merged feature (match by keyword from the PR title). Change `- [ ]` to `- [x]` for that line only.
+
+```
+gh issue edit <meta-issue> --repo sachaos/todoist --body "<updated body>"
+```
+
+## Step 5 — Update memory
+
+Update your memory for this project: move the completed item from open to completed, recording the spec issue number, PR number, and today's date.
+
+## Step 6 — Report
+
+Tell the user:
+- The PR was merged
+- Which meta-issue item was checked off
+- What open items remain

--- a/.claude/commands/todoist-spec.md
+++ b/.claude/commands/todoist-spec.md
@@ -1,0 +1,68 @@
+---
+description: Draft a user-facing spec for a feature from the meta feature-gaps issue, drive design decisions interactively, then post as a sub-issue.
+model: claude-opus-4-7
+---
+
+You are helping implement features for the todoist CLI. Your job is to research the codebase, draft a user-facing spec, drive interactive design decisions, and post the approved spec as a new GitHub sub-issue of the active meta-issue.
+
+## Step 1 — Identify the meta-issue
+
+Check your memory for the active meta-issue number (look for a memory about "meta-issue" or "feature gaps tracker"). If not found, ask the user: "Which GitHub issue is the current feature-gaps tracker for this repo?" Save their answer to memory before continuing.
+
+## Step 2 — Pick the feature
+
+If the user provided a feature name as an argument, use that. Otherwise:
+- Run `gh issue view <meta-issue> --repo sachaos/todoist` to get the current list
+- Show the user the unchecked items and ask which one to spec
+
+## Step 3 — Research
+
+Spawn two agents in parallel (both Sonnet):
+
+**Agent A (Explore):** Research the codebase for patterns relevant to this feature:
+- How similar existing commands are structured (`close.go`, `delete.go`, `modify.go` as references)
+- What `lib/` functions already exist that might be relevant
+- What API communication patterns are used (`doRestApi` vs `ExecCommands`/sync)
+- What flags/options similar commands use
+
+**Agent B (API research):** Search the OpenAPI spec at `todoist-openapi.json` in the repo root (fetch a fresh copy if missing: `curl -s https://developer.todoist.com/openapi.json -o todoist-openapi.json`). Find:
+- The relevant REST endpoint(s) and HTTP methods
+- Required parameters and response codes (especially: does it return 200 or 204?)
+- Any side effects documented in the API description
+- Whether a sync API command equivalent exists
+
+## Step 4 — Draft the spec
+
+Write a user-facing spec covering:
+- **Command shape**: name, aliases (or lack thereof), args, flags
+- **Behavior**: what it does, success/failure cases, side effects
+- **Help text**: what `--help` should show, including caveats
+- **API choice**: REST vs sync command, and why
+- **Cache behavior**: does it need to call `Sync()` after? Why or why not?
+- **UX considerations**: watch for flag name collisions, upper/lowercase issues, conflicts with existing flags (per CLAUDE.md)
+- **Out of scope**: what this PR won't include
+
+## Step 5 — Resolve design decisions
+
+Present the spec, then work through this standard punch list interactively. Skip questions with obvious answers from the research:
+
+1. **Command name** — matches Todoist's terminology? Any collision with existing commands?
+2. **Aliases** — short alias or none? Existing aliases in use: `l, a, m, c, d, s, q, ap, cl, c-l`
+3. **Flag names** — any UX problems (similar names, upper/lowercase collisions, conflicts)?
+4. **API approach** — REST or sync command? Batch or sequential?
+5. **Error behavior** — stop on first error, or continue and report all?
+6. **Success output** — silent (like `close`/`delete`) or print confirmation?
+7. **Cache/sync** — call `Sync()` after, or not? Why?
+8. **Side effects** — does the API do anything surprising (e.g. affects parent tasks)?
+9. **Partial failure recovery** — what does the user do if only some IDs succeed?
+
+Resolve each one before moving on. State your recommendation for each and ask the user to confirm or redirect.
+
+## Step 6 — Post the issue
+
+Once the user approves the spec, post it as a new GitHub issue:
+- Title: concise, imperative ("Add `X` command to...")
+- Body: the full spec in markdown, opening with "Proposal for [item] tracked in #<meta-issue>"
+- Link it as a sub-issue: `gh api -X POST /repos/sachaos/todoist/issues/<meta-issue>/sub_issues -F sub_issue_id=<new-issue-id>`
+
+Report the new issue URL to the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,76 @@ Command types: `item_add`, `item_update`, `item_close`, `item_delete`, `item_mov
 - **Shell completion**: Supports bash/zsh autocomplete via urfave/cli
 - **Browser integration**: Can open URLs embedded in task content (markdown links)
 
+## Architectural Guidelines
+
+These rules reflect hard-won patterns. Follow them when adding or modifying commands.
+
+### REST vs Sync API
+
+Use the **Sync API** (`ExecCommands`) for operations on **active tasks** that live in the local cache — add, update, close, delete, move. These can be batched atomically.
+
+Use the **REST API** (`doRestApi`) when:
+- The operation targets resources **not in the local cache** (e.g. completed tasks, which are fetched live and never cached)
+- No sync command type exists for the operation
+- The endpoint is one-shot by nature (e.g. `POST /tasks/{id}/reopen`)
+
+### When to call Sync(c) after a mutation
+
+**Call `Sync(c)`** when the command modifies an active task that is currently in the local cache. This keeps `todoist list` accurate immediately after the operation. Examples: `close`, `delete`, `add`, `modify`.
+
+**Do NOT call `Sync(c)`** when the command operates on completed tasks or resources that were never in the cache. The cache stays internally consistent because it never held those items. Examples: `reopen`. Add a comment explaining the omission so future maintainers don't add it back by mistake.
+
+### doRestApi behavior
+
+`doRestApi` in `lib/todoist.go` treats both **200 OK** and **204 No Content** as success. When adding a new REST-based lib function, always check the OpenAPI spec (at `todoist-openapi.json` in the repo root) to confirm which status code the endpoint returns — don't assume 200.
+
+### Lib layer conventions
+
+Functions in `lib/item.go` that operate on multiple IDs take `[]string`, not a single `string`. This keeps the lib API consistent and lets callers decide whether to loop or not. Example signatures:
+```go
+func (c *Client) CloseItem(ctx context.Context, ids []string) error
+func (c *Client) DeleteItem(ctx context.Context, ids []string) error
+```
+
+### Error handling conventions
+
+When a CLI handler loops over multiple IDs, **stop on first error** and wrap the error with the failing ID for clarity:
+```go
+if err := client.SomeOperation(ctx, id); err != nil {
+    return fmt.Errorf("failed to <action> task %s: %w", id, err)
+}
+```
+
+This lets users re-run the command with the remaining IDs after fixing the cause.
+
+### Command registration conventions
+
+In `main.go`, every command must have:
+- `ArgsUsage` — describes expected arguments (e.g. `"<Item ID> [<Item ID>...]"`)
+- `Description` — multi-line string shown in `--help`; explain non-obvious behavior (cache effects, side effects, recovery from partial failure)
+
+When a command is invoked with no arguments and arguments are required, return a descriptive error with usage guidance — not the generic `CommandFailed`:
+```go
+if c.Args().Len() == 0 {
+    return fmt.Errorf("no task IDs provided\nUsage: todoist <cmd> <Item ID> [<Item ID>...]\n...")
+}
+```
+
+### Existing command aliases
+
+These single-letter aliases are taken: `l`, `a`, `m`, `c`, `d`, `s`, `q`. These multi-character aliases are taken: `ap`, `cl`, `c-l`. Do not reuse them. New commands may omit an alias rather than introduce a confusing one.
+
+### Cache architecture
+
+The local cache (`~/.cache/todoist/cache.json`) stores only **active** tasks. Completed tasks are never cached — they are always fetched live from `GET /tasks/completed/by_completion_date`. Reopening a completed task does not require a cache update; the task will appear in `todoist list` after the next `todoist sync`.
+
+### Testing approach
+
+The test infrastructure supports two patterns:
+
+1. **Pure logic and read-only handlers**: Use `newTestContext()` from `show_test.go` with an in-memory `Store`. No HTTP calls needed. Always test the zero-args guard this way.
+2. **Mutation handlers**: These require HTTP mocking (no `httptest.Server` infrastructure currently exists). Follow the existing convention — mutation handlers (`close`, `delete`, `add`) have no tests. Do not introduce HTTP mocking infrastructure without explicit discussion.
+
 ## Dependencies
 
 Key dependencies (from go.mod):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,9 @@ Use the **REST API** (`doRestApi`) when:
 
 ### When to call Sync(c) after a mutation
 
-**Call `Sync(c)`** when the command modifies an active task that is currently in the local cache. This keeps `todoist list` accurate immediately after the operation.
+**Call `Sync(c)`** when the command modifies an active task that is currently in the local cache. This keeps `todoist list` accurate immediately after the operation. Examples: `close`, `delete`, `add`, `modify`.
 
-**Do NOT call `Sync(c)`** when the command operates on completed tasks or resources that were never in the cache. The cache stays internally consistent because it never held those items. Add a comment in the handler explaining the omission so future maintainers don't add it back by mistake.
+**Do NOT call `Sync(c)`** when the command operates on completed tasks or resources that were never in the cache. The cache stays internally consistent because it never held those items. Examples: `reopen`. Add a comment in the handler explaining the omission so future maintainers don't add it back by mistake.
 
 ### doRestApi behavior
 
@@ -205,7 +205,7 @@ if c.Args().Len() == 0 {
 
 ### Existing command aliases
 
-These single-letter aliases are taken: `l`, `a`, `m`, `c`, `d`, `s`, `q`. These multi-character aliases are taken: `ap`, `cl`, `c-l`. Do not reuse them. New commands may omit an alias rather than introduce a confusing one.
+Check `main.go` for the current list of registered aliases before adding a new one. New commands may omit an alias rather than introduce a confusing one.
 
 ### Cache architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,9 @@ Use the **REST API** (`doRestApi`) when:
 
 ### When to call Sync(c) after a mutation
 
-**Call `Sync(c)`** when the command modifies an active task that is currently in the local cache. This keeps `todoist list` accurate immediately after the operation. Examples: `close`, `delete`, `add`, `modify`.
+**Call `Sync(c)`** when the command modifies an active task that is currently in the local cache. This keeps `todoist list` accurate immediately after the operation.
 
-**Do NOT call `Sync(c)`** when the command operates on completed tasks or resources that were never in the cache. The cache stays internally consistent because it never held those items. Examples: `reopen`. Add a comment explaining the omission so future maintainers don't add it back by mistake.
+**Do NOT call `Sync(c)`** when the command operates on completed tasks or resources that were never in the cache. The cache stays internally consistent because it never held those items. Add a comment in the handler explaining the omission so future maintainers don't add it back by mistake.
 
 ### doRestApi behavior
 


### PR DESCRIPTION
Adds three Claude Code skills to `.claude/commands/` to streamline the feature development workflow for items in the feature-gaps meta-issue.

## Skills

- **`/todoist-spec`** (Opus) — researches the codebase and OpenAPI spec, drafts a user-facing CLI spec, drives interactive design decisions, and posts the approved spec as a sub-issue of the active meta-issue
- **`/todoist-implement`** (Opus) — reads a spec issue, briefs a Sonnet implementation subagent, opens a PR, and runs code review
- **`/todoist-ship`** (Haiku) — squash merges a PR, checks off the item on the meta-issue, and updates memory

## Design notes

- Meta-issue number is read from Claude's memory at runtime, not hardcoded — works with any future meta-issue
- No local paths or confidential information embedded in skill files
- Models chosen by task complexity: Opus for reasoning-heavy spec/implement, Haiku for mechanical ship steps, Sonnet for subagents

🤖 Generated with [Claude Code](https://claude.com/claude-code)