### PR TITLE
Add --remote flag to list for server-side filter execution

### DIFF
--- a/lib/item.go
+++ b/lib/item.go
@@ -3,6 +3,7 @@ package todoist
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -262,6 +263,37 @@ func (c *Client) DeleteItem(ctx context.Context, ids []string) error {
 
 func (c *Client) ReopenItem(ctx context.Context, id string) error {
 	return c.doRestApi(ctx, http.MethodPost, "tasks/"+id+"/reopen", nil, nil)
+}
+
+type ItemFilterResponse struct {
+	Results    []Item  `json:"results"`
+	NextCursor *string `json:"next_cursor"`
+}
+
+// FilterItems calls GET /api/v1/tasks/filter with the given query string,
+// auto-paginating until exhausted (or until limit results are collected when limit > 0).
+// limit <= 0 means "no limit, fetch all pages".
+func (c *Client) FilterItems(ctx context.Context, query string, limit int) ([]Item, error) {
+	var results []Item
+	cursor := ""
+	for {
+		params := url.Values{"query": {query}}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var resp ItemFilterResponse
+		if err := c.doApi(ctx, http.MethodGet, "tasks/filter", params, &resp); err != nil {
+			return nil, err
+		}
+		results = append(results, resp.Results...)
+		if limit > 0 && len(results) >= limit {
+			return results[:limit], nil
+		}
+		if resp.NextCursor == nil || *resp.NextCursor == "" {
+			return results, nil
+		}
+		cursor = *resp.NextCursor
+	}
 }
 
 func (c *Client) MoveItem(ctx context.Context, item *Item, projectId string) error {

--- a/list.go
+++ b/list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -36,6 +37,13 @@ func sortItems(itemListPtr *[][]string, byIndex int) {
 }
 
 func List(c *cli.Context) error {
+	if c.Bool("remote") {
+		return listRemote(c)
+	}
+	return listLocal(c)
+}
+
+func listLocal(c *cli.Context) error {
 	client := GetClient(c)
 
 	colorList := ColorList()
@@ -77,6 +85,56 @@ func List(c *cli.Context) error {
 	if c.Bool("priority") == true {
 		// sort output by priority
 		// and no need to use "else block" as items returned by API are already sorted by task id
+		sortItems(&itemList, 1)
+	}
+
+	defer writer.Flush()
+
+	if c.Bool("header") {
+		writer.Write([]string{"ID", "Priority", "DueDate", "Project", "Labels", "Content"})
+	}
+
+	for _, strings := range itemList {
+		writer.Write(strings)
+	}
+
+	return nil
+}
+
+func listRemote(c *cli.Context) error {
+	filter := c.String("filter")
+	if filter == "" {
+		return fmt.Errorf("--remote requires --filter")
+	}
+
+	client := GetClient(c)
+
+	items, err := client.FilterItems(context.Background(), filter, c.Int("limit"))
+	if err != nil {
+		return err
+	}
+
+	colorList := ColorList()
+	var projectIds []string
+	for _, project := range client.Store.Projects {
+		projectIds = append(projectIds, project.GetID())
+	}
+	projectColorHash := GenerateColorHash(projectIds, colorList)
+
+	itemList := [][]string{}
+	for _, item := range items {
+		itemList = append(itemList, []string{
+			IdFormat(item),
+			PriorityFormat(item.Priority),
+			DueDateFormat(item.DateTime(), item.AllDay),
+			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c) +
+				SectionFormat(item.SectionID, client.Store, c),
+			item.LabelsString(),
+			ContentFormat(item),
+		})
+	}
+
+	if c.Bool("priority") {
 		sortItems(&itemList, 1)
 	}
 

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	todoist "github.com/sachaos/todoist/lib"
+	"github.com/urfave/cli/v2"
+)
+
+func TestListRemote_NoFilter(t *testing.T) {
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = testStore()
+
+	app := cli.NewApp()
+	app.Metadata = map[string]interface{}{
+		"client": client,
+	}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.Bool("remote", false, "")
+	flagSet.String("filter", "", "")
+	flagSet.Int("limit", 0, "")
+	flagSet.Parse([]string{})
+	flagSet.Set("remote", "true")
+
+	ctx := cli.NewContext(app, flagSet, nil)
+
+	err := List(ctx)
+	if err == nil {
+		t.Fatal("expected error when --remote used without --filter, got nil")
+	}
+	if err.Error() != "--remote requires --filter" {
+		t.Errorf("expected '--remote requires --filter', got: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -106,6 +106,15 @@ func main() {
 		Aliases: []string{"p"},
 		Usage:   "sort the output by priority",
 	}
+	remoteFlag := cli.BoolFlag{
+		Name:    "remote",
+		Aliases: []string{"r"},
+		Usage:   "execute filter on Todoist's servers instead of the local parser (requires --filter)",
+	}
+	limitFlag := cli.IntFlag{
+		Name:  "limit",
+		Usage: "cap total results returned when --remote is set (default: no limit)",
+	}
 	reminderFlg := cli.BoolFlag{
 		Name:    "reminder",
 		Aliases: []string{"r"},
@@ -270,8 +279,15 @@ func main() {
 			Flags: []cli.Flag{
 				&filterFlag,
 				&sortPriorityFlag,
+				&remoteFlag,
+				&limitFlag,
 			},
 			ArgsUsage: " ",
+			Description: "By default, --filter is parsed locally and applied to the cached task store.\n" +
+				"With --remote, the filter is sent to Todoist's server for evaluation,\n" +
+				"which supports the full filter syntax including features the local\n" +
+				"parser doesn't handle. --remote requires --filter.\n\n" +
+				"Results auto-paginate; use --limit to cap the total number returned.",
 		},
 		{
 			Name:   "show",


### PR DESCRIPTION
Closes #303

## Summary

Adds a `--remote` / `-r` flag to `todoist list` that sends the `--filter` query to Todoist's server (`GET /api/v1/tasks/filter`) instead of evaluating it with the local yacc parser. This supports the full Todoist filter syntax — including edge cases the local parser doesn't handle (recurring instances, future filter features).

A companion `--limit <n>` flag caps the total number of results returned. Without `--limit`, all pages are fetched.

## Changes

- **`lib/item.go`** — adds `FilterItems(ctx, query, limit)` and `ItemFilterResponse` struct. Uses `doApi` (which already supports GET with URL params, like `CompletedAll`). Auto-paginates via `next_cursor`; respects `limit > 0` as a total cap.
- **`main.go`** — defines `remoteFlag` and `limitFlag`; wires them onto `list`; adds a `Description` block explaining the new flags.
- **`list.go`** — `List` is now a thin dispatcher: if `--remote`, calls `listRemote`; otherwise the original `listLocal` path. `listRemote` validates that `--filter` is set, calls `FilterItems`, and renders the same 6-column output (ID · Priority · DueDate · Project/Section · Labels · Content) using the existing format functions.

## Design notes

- **API choice**: REST GET via `doApi`. No sync command exists for ad-hoc filter queries.
- **No `Sync()` after**: read-only operation; cache is not modified.
- **Project/section names** are still resolved from the local cache. If the cache is stale, names may not match — user should `todoist sync` first.
- **`--namespace` and `--indent` are silently ignored** when `--remote` is set: server results are flat with no parent/child tree to walk.
- **`-r` alias**: collides with the `--reminder` flag's alias on `add`, but flag aliases only conflict within the same command, so this is fine.

## Test plan

- [x] `make build`
- [x] `make test` (24 tests pass)
- [x] `todoist list --filter "today" --remote` returns server-evaluated results
- [x] `todoist list --remote` (no filter) prints `--remote requires --filter`
- [x] `todoist list --filter "today" --remote --limit 5` caps at 5 results
- [x] `todoist list --filter "..." --remote --priority` sorts by priority
- [x] Local `todoist list --filter "today"` (no `--remote`) is unchanged