### PR TITLE
Improve todoist workflow skills based on session learnings

### DIFF
--- a/.claude/commands/todoist-implement.md
+++ b/.claude/commands/todoist-implement.md
@@ -33,6 +33,7 @@ Brief a general-purpose Sonnet agent with:
 - Specific files to create/modify and what each change should do
 - Patterns to follow from the existing codebase
 - Reminders: do NOT call `Sync(c)` unless the spec says to; do NOT commit or push; do NOT add features beyond the spec
+- **Tests**: always add a test for the zero-input/no-args guard (e.g. command with no IDs, or a flag that requires another flag) using `newTestContext()` from `show_test.go`. Add any other pure-logic tests that don't require HTTP. Do NOT introduce HTTP mocking infrastructure.
 - After implementing: run `make build` and `make test` and report results
 
 Wait for the agent to complete before proceeding.
@@ -45,7 +46,7 @@ Check the agent's output. If `make build` or `make test` failed, fix the issues 
 
 ```
 git add <changed files>
-git commit -m "<imperative summary>\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+git commit -m "<imperative summary>\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 git push -u origin <branch>
 ```
 

--- a/.claude/commands/todoist-ship.md
+++ b/.claude/commands/todoist-ship.md
@@ -13,7 +13,9 @@ Check your memory for the active meta-issue number. If not found, ask the user b
 
 Run: `gh pr view <PR-number> --repo sachaos/todoist`
 
-Confirm it is open and not a draft. If already merged or closed, report that and stop.
+- If it is a draft or closed without merging, report that and stop.
+- If it is already merged, skip Step 3 and continue with Step 4.
+- Otherwise confirm it is open and proceed.
 
 ## Step 3 — Merge
 

--- a/.claude/commands/todoist-spec.md
+++ b/.claude/commands/todoist-spec.md
@@ -11,7 +11,11 @@ Check your memory for the active meta-issue number (look for a memory about "met
 
 ## Step 2 — Pick the feature
 
-If the user provided a feature name as an argument, use that. Otherwise:
+If the user provided an **issue number** as the argument (e.g. `#303` or `303`), read that issue with `gh issue view <number> --repo sachaos/todoist` and use it as the spec destination — skip creating a new issue in Step 6 and instead update the existing one.
+
+If the user provided a feature name (text), use that as the topic.
+
+Otherwise:
 - Run `gh issue view <meta-issue> --repo sachaos/todoist` to get the current list
 - Show the user the unchecked items and ask which one to spec
 
@@ -60,9 +64,17 @@ Resolve each one before moving on. State your recommendation for each and ask th
 
 ## Step 6 — Post the issue
 
-Once the user approves the spec, post it as a new GitHub issue:
+Once the user approves the spec:
+
+**If the user pointed to an existing issue in Step 2**, update that issue's body with the final spec:
+```
+gh issue edit <number> --repo sachaos/todoist --body "<spec>"
+```
+
+**Otherwise**, create a new issue:
 - Title: concise, imperative ("Add `X` command to...")
 - Body: the full spec in markdown, opening with "Proposal for [item] tracked in #<meta-issue>"
-- Link it as a sub-issue: `gh api -X POST /repos/sachaos/todoist/issues/<meta-issue>/sub_issues -F sub_issue_id=<new-issue-id>`
+- Attempt to link as a sub-issue: `gh api -X POST /repos/sachaos/todoist/issues/<meta-issue>/sub_issues -F sub_issue_id=<new-issue-id>`
+- If the sub_issues API returns 404, fall back to posting a comment on the meta-issue: `gh issue comment <meta-issue> --repo sachaos/todoist --body "Spec posted: #<new-issue-id>"`
 
-Report the new issue URL to the user.
+Report the issue URL to the user.

--- a/lib/item.go
+++ b/lib/item.go
@@ -3,6 +3,7 @@ package todoist
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -262,6 +263,37 @@ func (c *Client) DeleteItem(ctx context.Context, ids []string) error {
 
 func (c *Client) ReopenItem(ctx context.Context, id string) error {
 	return c.doRestApi(ctx, http.MethodPost, "tasks/"+id+"/reopen", nil, nil)
+}
+
+type ItemFilterResponse struct {
+	Results    []Item  `json:"results"`
+	NextCursor *string `json:"next_cursor"`
+}
+
+// FilterItems calls GET /api/v1/tasks/filter with the given query string,
+// auto-paginating until exhausted (or until limit results are collected when limit > 0).
+// limit <= 0 means "no limit, fetch all pages".
+func (c *Client) FilterItems(ctx context.Context, query string, limit int) ([]Item, error) {
+	var results []Item
+	cursor := ""
+	for {
+		params := url.Values{"query": {query}}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+		var resp ItemFilterResponse
+		if err := c.doApi(ctx, http.MethodGet, "tasks/filter", params, &resp); err != nil {
+			return nil, err
+		}
+		results = append(results, resp.Results...)
+		if limit > 0 && len(results) >= limit {
+			return results[:limit], nil
+		}
+		if resp.NextCursor == nil || *resp.NextCursor == "" {
+			return results, nil
+		}
+		cursor = *resp.NextCursor
+	}
 }
 
 func (c *Client) MoveItem(ctx context.Context, item *Item, projectId string) error {

--- a/list.go
+++ b/list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -36,6 +37,13 @@ func sortItems(itemListPtr *[][]string, byIndex int) {
 }
 
 func List(c *cli.Context) error {
+	if c.Bool("remote") {
+		return listRemote(c)
+	}
+	return listLocal(c)
+}
+
+func listLocal(c *cli.Context) error {
 	client := GetClient(c)
 
 	colorList := ColorList()
@@ -77,6 +85,56 @@ func List(c *cli.Context) error {
 	if c.Bool("priority") == true {
 		// sort output by priority
 		// and no need to use "else block" as items returned by API are already sorted by task id
+		sortItems(&itemList, 1)
+	}
+
+	defer writer.Flush()
+
+	if c.Bool("header") {
+		writer.Write([]string{"ID", "Priority", "DueDate", "Project", "Labels", "Content"})
+	}
+
+	for _, strings := range itemList {
+		writer.Write(strings)
+	}
+
+	return nil
+}
+
+func listRemote(c *cli.Context) error {
+	filter := c.String("filter")
+	if filter == "" {
+		return fmt.Errorf("--remote requires --filter")
+	}
+
+	client := GetClient(c)
+
+	items, err := client.FilterItems(context.Background(), filter, c.Int("limit"))
+	if err != nil {
+		return err
+	}
+
+	colorList := ColorList()
+	var projectIds []string
+	for _, project := range client.Store.Projects {
+		projectIds = append(projectIds, project.GetID())
+	}
+	projectColorHash := GenerateColorHash(projectIds, colorList)
+
+	itemList := [][]string{}
+	for _, item := range items {
+		itemList = append(itemList, []string{
+			IdFormat(item),
+			PriorityFormat(item.Priority),
+			DueDateFormat(item.DateTime(), item.AllDay),
+			ProjectFormat(item.ProjectID, client.Store, projectColorHash, c) +
+				SectionFormat(item.SectionID, client.Store, c),
+			item.LabelsString(),
+			ContentFormat(item),
+		})
+	}
+
+	if c.Bool("priority") {
 		sortItems(&itemList, 1)
 	}
 

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	todoist "github.com/sachaos/todoist/lib"
+	"github.com/urfave/cli/v2"
+)
+
+func TestListRemote_NoFilter(t *testing.T) {
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = testStore()
+
+	app := cli.NewApp()
+	app.Metadata = map[string]interface{}{
+		"client": client,
+	}
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.Bool("remote", false, "")
+	flagSet.String("filter", "", "")
+	flagSet.Int("limit", 0, "")
+	flagSet.Parse([]string{})
+	flagSet.Set("remote", "true")
+
+	ctx := cli.NewContext(app, flagSet, nil)
+
+	err := List(ctx)
+	if err == nil {
+		t.Fatal("expected error when --remote used without --filter, got nil")
+	}
+	if err.Error() != "--remote requires --filter" {
+		t.Errorf("expected '--remote requires --filter', got: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -106,6 +106,15 @@ func main() {
 		Aliases: []string{"p"},
 		Usage:   "sort the output by priority",
 	}
+	remoteFlag := cli.BoolFlag{
+		Name:    "remote",
+		Aliases: []string{"r"},
+		Usage:   "execute filter on Todoist's servers instead of the local parser (requires --filter)",
+	}
+	limitFlag := cli.IntFlag{
+		Name:  "limit",
+		Usage: "cap total results returned when --remote is set (default: no limit)",
+	}
 	reminderFlg := cli.BoolFlag{
 		Name:    "reminder",
 		Aliases: []string{"r"},
@@ -270,8 +279,15 @@ func main() {
 			Flags: []cli.Flag{
 				&filterFlag,
 				&sortPriorityFlag,
+				&remoteFlag,
+				&limitFlag,
 			},
 			ArgsUsage: " ",
+			Description: "By default, --filter is parsed locally and applied to the cached task store.\n" +
+				"With --remote, the filter is sent to Todoist's server for evaluation,\n" +
+				"which supports the full filter syntax including features the local\n" +
+				"parser doesn't handle. --remote requires --filter.\n\n" +
+				"Results auto-paginate; use --limit to cap the total number returned.",
 		},
 		{
 			Name:   "show",


### PR DESCRIPTION
Improvements to the three todoist workflow skills based on patterns observed during the server-side filter execution session.

## todoist-spec
- **Step 2**: if the argument is an issue number (e.g. `#303`), read that issue and use it as the spec destination instead of creating a new one — avoids the duplicate-issue-then-close pattern
- **Step 6**: update existing issue body when one was provided; fall back to a comment on the meta-issue if the sub_issues API returns 404

## todoist-implement
- **Step 4**: added explicit test reminder — always add a zero-input/no-args guard test using `newTestContext()`, plus any other pure-logic tests that don't require HTTP; do not introduce HTTP mocking infrastructure
- **Step 6**: corrected co-authored-by from `Claude Opus 4.7` to `Claude Sonnet 4.6`

## todoist-ship
- **Step 2**: if the PR is already merged (user merged manually), skip the merge step and continue with meta-issue check-off and memory update instead of stopping