### PR TITLE
Add --deadline flag to add and modify commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor
 
 # Downloaded API specifications
 todoist-openapi.json
+.playwright-mcp/

--- a/add.go
+++ b/add.go
@@ -64,18 +64,19 @@ func Add(c *cli.Context) error {
 
 	item.Due = &todoist.Due{String: c.String("date")}
 
-	item.AutoReminder = c.Bool("reminder")
-
-	newID, err := client.AddItem(context.Background(), item)
-	if err != nil {
-		return err
-	}
-
 	if c.IsSet("deadline") {
 		deadlineDate := c.String("deadline")
-		if err := client.UpdateItemDeadline(context.Background(), newID, deadlineDate); err != nil {
-			return fmt.Errorf("failed to update deadline for task %s: %w", newID, err)
+		if deadlineDate == "" || deadlineDate == "null" {
+			item.Deadline = &todoist.Deadline{Date: ""}
+		} else {
+			item.Deadline = &todoist.Deadline{Date: deadlineDate}
 		}
+	}
+
+	item.AutoReminder = c.Bool("reminder")
+
+	if err := client.AddItem(context.Background(), item); err != nil {
+		return err
 	}
 
 	return Sync(c)

--- a/add.go
+++ b/add.go
@@ -66,8 +66,16 @@ func Add(c *cli.Context) error {
 
 	item.AutoReminder = c.Bool("reminder")
 
-	if err := client.AddItem(context.Background(), item); err != nil {
+	newID, err := client.AddItem(context.Background(), item)
+	if err != nil {
 		return err
+	}
+
+	if c.IsSet("deadline") {
+		deadlineDate := c.String("deadline")
+		if err := client.UpdateItemDeadline(context.Background(), newID, deadlineDate); err != nil {
+			return fmt.Errorf("failed to update deadline for task %s: %w", newID, err)
+		}
 	}
 
 	return Sync(c)

--- a/lib/item.go
+++ b/lib/item.go
@@ -179,6 +179,9 @@ func (item Item) AddParam() interface{} {
 	if item.Due != nil {
 		param["due"] = item.Due
 	}
+	if item.Deadline != nil {
+		param["deadline"] = item.Deadline
+	}
 	if item.SectionID != "" {
 		param["section_id"] = item.SectionID
 	}
@@ -214,6 +217,9 @@ func (item Item) UpdateParam() interface{} {
 	if item.Due != nil {
 		param["due"] = item.Due
 	}
+	if item.Deadline != nil {
+		param["deadline"] = item.Deadline
+	}
 	if item.Description != "" {
 		param["description"] = item.Description
 	}
@@ -235,17 +241,11 @@ func (item Item) LabelsString() string {
 	return "@" + strings.Join(item.LabelNames, ",@")
 }
 
-// AddItem creates a new task and returns the new item's real ID.
-// The ID is extracted from the temp_id_mapping returned by the sync API.
-func (c *Client) AddItem(ctx context.Context, item Item) (string, error) {
-	command := NewCommand("item_add", item.AddParam())
-	commands := Commands{command}
-	result, err := c.execCommandsWithResult(ctx, commands)
-	if err != nil {
-		return "", err
+func (c *Client) AddItem(ctx context.Context, item Item) error {
+	commands := Commands{
+		NewCommand("item_add", item.AddParam()),
 	}
-	newID := result.TempIdMapping[command.TempID]
-	return newID, nil
+	return c.ExecCommands(ctx, commands)
 }
 
 func (c *Client) UpdateItem(ctx context.Context, item Item) error {
@@ -275,21 +275,6 @@ func (c *Client) DeleteItem(ctx context.Context, ids []string) error {
 
 func (c *Client) ReopenItem(ctx context.Context, id string) error {
 	return c.doRestApi(ctx, http.MethodPost, "tasks/"+id+"/reopen", nil, nil)
-}
-
-// UpdateItemDeadline sets or clears the deadline date for a task.
-// Pass an empty string or "null" to clear the deadline; pass a YYYY-MM-DD date to set it.
-func (c *Client) UpdateItemDeadline(ctx context.Context, itemID string, deadlineDate string) error {
-	var deadlineValue interface{}
-	if deadlineDate == "" || deadlineDate == "null" {
-		deadlineValue = nil
-	} else {
-		deadlineValue = deadlineDate
-	}
-	body := map[string]interface{}{
-		"deadline_date": deadlineValue,
-	}
-	return c.doRestApi(ctx, http.MethodPost, "tasks/"+itemID, body, nil)
 }
 
 type ItemFilterResponse struct {

--- a/lib/item.go
+++ b/lib/item.go
@@ -27,6 +27,11 @@ type Due struct {
 	Lang        string `json:"lang"`
 }
 
+type Deadline struct {
+	Date string `json:"date"`
+	Lang string `json:"lang,omitempty"`
+}
+
 type BaseItem struct {
 	HaveID
 	HaveProjectID
@@ -77,6 +82,7 @@ type Item struct {
 	DateString     string      `json:"date_string"`
 	DayOrder       int         `json:"day_order"`
 	Due            *Due        `json:"due"`
+	Deadline       *Deadline   `json:"deadline"`
 	HasMoreNotes   bool        `json:"has_more_notes"`
 	IsArchived     int         `json:"is_archived"`
 	IsDeleted      bool        `json:"is_deleted"`
@@ -229,11 +235,17 @@ func (item Item) LabelsString() string {
 	return "@" + strings.Join(item.LabelNames, ",@")
 }
 
-func (c *Client) AddItem(ctx context.Context, item Item) error {
-	commands := Commands{
-		NewCommand("item_add", item.AddParam()),
+// AddItem creates a new task and returns the new item's real ID.
+// The ID is extracted from the temp_id_mapping returned by the sync API.
+func (c *Client) AddItem(ctx context.Context, item Item) (string, error) {
+	command := NewCommand("item_add", item.AddParam())
+	commands := Commands{command}
+	result, err := c.execCommandsWithResult(ctx, commands)
+	if err != nil {
+		return "", err
 	}
-	return c.ExecCommands(ctx, commands)
+	newID := result.TempIdMapping[command.TempID]
+	return newID, nil
 }
 
 func (c *Client) UpdateItem(ctx context.Context, item Item) error {
@@ -263,6 +275,21 @@ func (c *Client) DeleteItem(ctx context.Context, ids []string) error {
 
 func (c *Client) ReopenItem(ctx context.Context, id string) error {
 	return c.doRestApi(ctx, http.MethodPost, "tasks/"+id+"/reopen", nil, nil)
+}
+
+// UpdateItemDeadline sets or clears the deadline date for a task.
+// Pass an empty string or "null" to clear the deadline; pass a YYYY-MM-DD date to set it.
+func (c *Client) UpdateItemDeadline(ctx context.Context, itemID string, deadlineDate string) error {
+	var deadlineValue interface{}
+	if deadlineDate == "" || deadlineDate == "null" {
+		deadlineValue = nil
+	} else {
+		deadlineValue = deadlineDate
+	}
+	body := map[string]interface{}{
+		"deadline_date": deadlineValue,
+	}
+	return c.doRestApi(ctx, http.MethodPost, "tasks/"+itemID, body, nil)
 }
 
 type ItemFilterResponse struct {

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -142,10 +142,10 @@ func (c *Client) doRestApi(ctx context.Context, method string, uri string, body 
 type ExecResult struct {
 	SyncToken     string                 `json:"sync_token"`
 	SyncStatus    map[string]interface{} `json:"sync_status"`
-	TempIdMapping map[string]string      `json:"temp_id_mapping"`
+	TempIdMapping interface{}            `json:"temp_id_mapping"`
 }
 
-func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) (ExecResult, error) {
+func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 	var r ExecResult
 	params := commands.UrlValues()
 	if c.Store != nil && c.Store.SyncToken != "" {
@@ -155,7 +155,7 @@ func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) 
 	}
 
 	if err := c.doApi(ctx, http.MethodPost, "sync", params, &r); err != nil {
-		return r, err
+		return err
 	}
 
 	for _, command := range commands {
@@ -165,16 +165,11 @@ func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) 
 		}
 
 		if status != "ok" {
-			return r, fmt.Errorf("command %s failed: %v", command.Type, status)
+			return fmt.Errorf("command %s failed: %v", command.Type, status)
 		}
 	}
 
-	return r, nil
-}
-
-func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
-	_, err := c.execCommandsWithResult(ctx, commands)
-	return err
+	return nil
 }
 
 func (c *Client) QuickCommand(ctx context.Context, text string) error {

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -142,10 +142,10 @@ func (c *Client) doRestApi(ctx context.Context, method string, uri string, body 
 type ExecResult struct {
 	SyncToken     string                 `json:"sync_token"`
 	SyncStatus    map[string]interface{} `json:"sync_status"`
-	TempIdMapping interface{}            `json:"temp_id_mapping"`
+	TempIdMapping map[string]string      `json:"temp_id_mapping"`
 }
 
-func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
+func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) (ExecResult, error) {
 	var r ExecResult
 	params := commands.UrlValues()
 	if c.Store != nil && c.Store.SyncToken != "" {
@@ -155,7 +155,7 @@ func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 	}
 
 	if err := c.doApi(ctx, http.MethodPost, "sync", params, &r); err != nil {
-		return err
+		return r, err
 	}
 
 	for _, command := range commands {
@@ -165,11 +165,16 @@ func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 		}
 
 		if status != "ok" {
-			return fmt.Errorf("command %s failed: %v", command.Type, status)
+			return r, fmt.Errorf("command %s failed: %v", command.Type, status)
 		}
 	}
 
-	return nil
+	return r, nil
+}
+
+func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
+	_, err := c.execCommandsWithResult(ctx, commands)
+	return err
 }
 
 func (c *Client) QuickCommand(ctx context.Context, text string) error {

--- a/main.go
+++ b/main.go
@@ -132,6 +132,10 @@ func main() {
 		Name:  "description",
 		Usage: "task description",
 	}
+	deadlineFlag := cli.StringFlag{
+		Name:  "deadline",
+		Usage: "Task deadline date in YYYY-MM-DD format (e.g., 2025-02-12). Separate from due date. Pass empty string to clear the deadline.",
+	}
 
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
@@ -323,6 +327,7 @@ func main() {
 				&dateFlag,
 				&reminderFlg,
 				&descriptionFlag,
+				&deadlineFlag,
 			},
 			ArgsUsage: "<Item content>",
 		},
@@ -341,6 +346,7 @@ func main() {
 				&sectionNameFlag,
 				&dateFlag,
 				&descriptionFlag,
+				&deadlineFlag,
 			},
 			ArgsUsage: "<Item ID>",
 		},

--- a/modify.go
+++ b/modify.go
@@ -39,6 +39,15 @@ func Modify(c *cli.Context) error {
 
 	item.Due = &todoist.Due{String: c.String("date")}
 
+	if c.IsSet("deadline") {
+		deadlineDate := c.String("deadline")
+		if deadlineDate == "" || deadlineDate == "null" {
+			item.Deadline = &todoist.Deadline{Date: ""}
+		} else {
+			item.Deadline = &todoist.Deadline{Date: deadlineDate}
+		}
+	}
+
 	projectID := c.String("project-id")
 	if projectID == "" {
 		projectID = client.Store.Projects.GetIDByName(c.String("project-name"))
@@ -66,13 +75,6 @@ func Modify(c *cli.Context) error {
 	if sectionID != "" {
 		if err := client.MoveItemToSection(context.Background(), item, sectionID); err != nil {
 			return err
-		}
-	}
-
-	if c.IsSet("deadline") {
-		deadlineDate := c.String("deadline")
-		if err := client.UpdateItemDeadline(context.Background(), item_id, deadlineDate); err != nil {
-			return fmt.Errorf("failed to update deadline for task %s: %w", item_id, err)
 		}
 	}
 

--- a/modify.go
+++ b/modify.go
@@ -69,5 +69,12 @@ func Modify(c *cli.Context) error {
 		}
 	}
 
+	if c.IsSet("deadline") {
+		deadlineDate := c.String("deadline")
+		if err := client.UpdateItemDeadline(context.Background(), item_id, deadlineDate); err != nil {
+			return fmt.Errorf("failed to update deadline for task %s: %w", item_id, err)
+		}
+	}
+
 	return Sync(c)
 }

--- a/show.go
+++ b/show.go
@@ -42,6 +42,9 @@ func Show(c *cli.Context) error {
 		[]string{"DueDate", DueDateFormat(item.DateTime(), item.AllDay)},
 		[]string{"URL", strings.Join(todoist.GetContentURL(item), ",")},
 	}
+	if item.Deadline != nil && item.Deadline.Date != "" {
+		records = append(records, []string{"Deadline", item.Deadline.Date})
+	}
 	defer writer.Flush()
 
 	for _, record := range records {

--- a/show.go
+++ b/show.go
@@ -40,11 +40,12 @@ func Show(c *cli.Context) error {
 		[]string{"Labels", item.LabelsString()},
 		[]string{"Priority", PriorityFormat(item.Priority)},
 		[]string{"DueDate", DueDateFormat(item.DateTime(), item.AllDay)},
-		[]string{"URL", strings.Join(todoist.GetContentURL(item), ",")},
 	}
 	if item.Deadline != nil && item.Deadline.Date != "" {
 		records = append(records, []string{"Deadline", item.Deadline.Date})
 	}
+	records = append(records, []string{"URL", strings.Join(todoist.GetContentURL(item), ",")})
+
 	defer writer.Flush()
 
 	for _, record := range records {

--- a/show_test.go
+++ b/show_test.go
@@ -114,6 +114,67 @@ func TestShow_Section(t *testing.T) {
 	}
 }
 
+func TestShow_ItemWithDeadline(t *testing.T) {
+	color.NoColor = true
+
+	store := testStore()
+	// Add a second item with a deadline
+	store.Items = append(store.Items, todoist.Item{
+		BaseItem: todoist.BaseItem{
+			HaveID:        todoist.HaveID{ID: "item-2"},
+			HaveProjectID: todoist.HaveProjectID{ProjectID: "proj-1"},
+			Content:       "Task with deadline",
+		},
+		Deadline: &todoist.Deadline{Date: "2025-02-12"},
+		Priority: 3,
+	})
+	store.ConstructItemTree()
+
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = store
+
+	ctx := newTestContext(client, []string{"item-2"})
+
+	var buf bytes.Buffer
+	writer = NewTSVWriter(&buf)
+
+	err := Show(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	output := buf.String()
+	if !bytes.Contains([]byte(output), []byte("Deadline")) {
+		t.Errorf("expected output to contain 'Deadline', got: %s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("2025-02-12")) {
+		t.Errorf("expected output to contain '2025-02-12', got: %s", output)
+	}
+}
+
+func TestShow_ItemWithoutDeadline(t *testing.T) {
+	color.NoColor = true
+
+	store := testStore()
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = store
+
+	ctx := newTestContext(client, []string{"item-1"})
+
+	var buf bytes.Buffer
+	writer = NewTSVWriter(&buf)
+
+	err := Show(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	output := buf.String()
+	if bytes.Contains([]byte(output), []byte("Deadline")) {
+		t.Errorf("expected output NOT to contain 'Deadline' when deadline is nil, got: %s", output)
+	}
+}
+
 func TestShow_NotFound(t *testing.T) {
 	color.NoColor = true
 


### PR DESCRIPTION
Closes #319

## Summary
Adds support for Todoist's deadline field via a new `--deadline` flag on both `todoist add` and `todoist modify`. Deadlines are set or cleared via the v1 REST API endpoint `POST /api/v1/tasks/{id}` (the sync command API has no deadline command type). The `show` command now displays the deadline when set.

## Files Modified
- `lib/item.go` — Added `Deadline` struct, `Deadline *Deadline` field on `Item`, new `UpdateItemDeadline` function. Changed `AddItem` signature from `error` to `(string, error)` to return the new item ID parsed from `temp_id_mapping`.
- `lib/todoist.go` — Refactored `ExecCommands` to delegate to a new internal helper `execCommandsWithResult` that returns the full `ExecResult`. Narrowed `ExecResult.TempIdMapping` from `interface{}` to `map[string]string` to enable typed access.
- `add.go` — Updated for the new `AddItem` signature; calls `UpdateItemDeadline` if `--deadline` was provided.
- `modify.go` — Calls `UpdateItemDeadline` if `--deadline` was provided.
- `main.go` — Defines `deadlineFlag` and registers it on both `add` and `modify`.
- `show.go` — Conditionally appends a `Deadline` row when present.
- `show_test.go` — Adds `TestShow_ItemWithDeadline` and `TestShow_ItemWithoutDeadline`.

## Design Notes

- **Why two API calls for one user action**: The Sync API's `item_add`/`item_update` commands don't accept `deadline_date`. The cleanest fix without restructuring the entire mutation flow is to issue an additional REST call to `/api/v1/tasks/{id}` after the sync command. The existing `Sync(c)` at the end of both handlers refreshes the cache, keeping `todoist list` accurate.
- **`AddItem` signature change**: Changed to return the new item ID since we need it to make the deadline REST call. There was only one caller (`add.go`), so the change is contained.
- **Detecting "flag provided" vs "default"**: Use `c.IsSet("deadline")` to distinguish. Without this guard, omitting the flag would clear the deadline (since `cli.StringFlag`'s default is `""`).
- **Clearing semantics**: Both `--deadline=""` and `--deadline=null` map to `deadline_date: null` in the JSON body.

## Test Plan
- [x] `make build` — clean
- [x] `make test` — all tests pass (incl. 2 new deadline tests)
- [ ] `todoist add "test task" --deadline 2025-12-01` — deadline appears in `todoist show <id>`
- [ ] `todoist modify <id> --deadline 2026-01-15` — deadline updates
- [ ] `todoist modify <id> --deadline ""` — deadline clears
- [ ] `todoist modify <id> --content "new title"` (no `--deadline`) — deadline preserved
- [ ] `todoist show <id>` on a task without a deadline — no Deadline row in output