### PR TITLE
Update todoist-implement to use Sonnet 4.6

### DIFF
--- a/.claude/commands/todoist-implement.md
+++ b/.claude/commands/todoist-implement.md
@@ -1,6 +1,6 @@
 ---
 description: Read a spec issue, implement the feature, open a PR, and run code review.
-model: claude-opus-4-7
+model: claude-sonnet-4-6
 ---
 
 You are implementing a feature for the todoist CLI. The spec is in a GitHub issue number provided as the argument.


### PR DESCRIPTION
## Summary
Updates the todoist-implement command to use Sonnet 4.6 instead of Opus 4.7. Sonnet is faster and better suited for this implementation task.

## Changes
- Updated model in .claude/commands/todoist-implement.md from claude-opus-4-7 to claude-sonnet-4-6