### PR TITLE
Fix deadline clearing logic

### DIFF
--- a/add.go
+++ b/add.go
@@ -66,11 +66,7 @@ func Add(c *cli.Context) error {
 
 	if c.IsSet("deadline") {
 		deadlineDate := c.String("deadline")
-		if deadlineDate == "" || deadlineDate == "null" {
-			item.Deadline = &todoist.Deadline{Date: ""}
-		} else {
-			item.Deadline = &todoist.Deadline{Date: deadlineDate}
-		}
+		item.Deadline = &todoist.Deadline{Date: deadlineDate}
 	}
 
 	item.AutoReminder = c.Bool("reminder")

--- a/add.go
+++ b/add.go
@@ -75,8 +75,16 @@ func Add(c *cli.Context) error {
 
 	item.AutoReminder = c.Bool("reminder")
 
-	if err := client.AddItem(context.Background(), item); err != nil {
+	newID, err := client.AddItem(context.Background(), item)
+	if err != nil {
 		return err
+	}
+
+	if c.IsSet("deadline") {
+		deadlineDate := c.String("deadline")
+		if err := client.UpdateItemDeadline(context.Background(), newID, deadlineDate); err != nil {
+			return fmt.Errorf("failed to update deadline for task %s: %w", newID, err)
+		}
 	}
 
 	return Sync(c)

--- a/add.go
+++ b/add.go
@@ -75,16 +75,8 @@ func Add(c *cli.Context) error {
 
 	item.AutoReminder = c.Bool("reminder")
 
-	newID, err := client.AddItem(context.Background(), item)
-	if err != nil {
+	if err := client.AddItem(context.Background(), item); err != nil {
 		return err
-	}
-
-	if c.IsSet("deadline") {
-		deadlineDate := c.String("deadline")
-		if err := client.UpdateItemDeadline(context.Background(), newID, deadlineDate); err != nil {
-			return fmt.Errorf("failed to update deadline for task %s: %w", newID, err)
-		}
 	}
 
 	return Sync(c)

--- a/lib/item.go
+++ b/lib/item.go
@@ -241,11 +241,17 @@ func (item Item) LabelsString() string {
 	return "@" + strings.Join(item.LabelNames, ",@")
 }
 
-func (c *Client) AddItem(ctx context.Context, item Item) error {
-	commands := Commands{
-		NewCommand("item_add", item.AddParam()),
+// AddItem creates a new task and returns the new item's real ID.
+// The ID is extracted from the temp_id_mapping returned by the sync API.
+func (c *Client) AddItem(ctx context.Context, item Item) (string, error) {
+	command := NewCommand("item_add", item.AddParam())
+	commands := Commands{command}
+	result, err := c.execCommandsWithResult(ctx, commands)
+	if err != nil {
+		return "", err
 	}
-	return c.ExecCommands(ctx, commands)
+	newID := result.TempIdMapping[command.TempID]
+	return newID, nil
 }
 
 func (c *Client) UpdateItem(ctx context.Context, item Item) error {
@@ -275,6 +281,21 @@ func (c *Client) DeleteItem(ctx context.Context, ids []string) error {
 
 func (c *Client) ReopenItem(ctx context.Context, id string) error {
 	return c.doRestApi(ctx, http.MethodPost, "tasks/"+id+"/reopen", nil, nil)
+}
+
+// UpdateItemDeadline sets or clears the deadline date for a task.
+// Pass an empty string or "null" to clear the deadline; pass a YYYY-MM-DD date to set it.
+func (c *Client) UpdateItemDeadline(ctx context.Context, itemID string, deadlineDate string) error {
+	var deadlineValue interface{}
+	if deadlineDate == "" || deadlineDate == "null" {
+		deadlineValue = nil
+	} else {
+		deadlineValue = deadlineDate
+	}
+	body := map[string]interface{}{
+		"deadline_date": deadlineValue,
+	}
+	return c.doRestApi(ctx, http.MethodPost, "tasks/"+itemID, body, nil)
 }
 
 type ItemFilterResponse struct {

--- a/lib/item.go
+++ b/lib/item.go
@@ -241,17 +241,11 @@ func (item Item) LabelsString() string {
 	return "@" + strings.Join(item.LabelNames, ",@")
 }
 
-// AddItem creates a new task and returns the new item's real ID.
-// The ID is extracted from the temp_id_mapping returned by the sync API.
-func (c *Client) AddItem(ctx context.Context, item Item) (string, error) {
-	command := NewCommand("item_add", item.AddParam())
-	commands := Commands{command}
-	result, err := c.execCommandsWithResult(ctx, commands)
-	if err != nil {
-		return "", err
+func (c *Client) AddItem(ctx context.Context, item Item) error {
+	commands := Commands{
+		NewCommand("item_add", item.AddParam()),
 	}
-	newID := result.TempIdMapping[command.TempID]
-	return newID, nil
+	return c.ExecCommands(ctx, commands)
 }
 
 func (c *Client) UpdateItem(ctx context.Context, item Item) error {
@@ -281,21 +275,6 @@ func (c *Client) DeleteItem(ctx context.Context, ids []string) error {
 
 func (c *Client) ReopenItem(ctx context.Context, id string) error {
 	return c.doRestApi(ctx, http.MethodPost, "tasks/"+id+"/reopen", nil, nil)
-}
-
-// UpdateItemDeadline sets or clears the deadline date for a task.
-// Pass an empty string or "null" to clear the deadline; pass a YYYY-MM-DD date to set it.
-func (c *Client) UpdateItemDeadline(ctx context.Context, itemID string, deadlineDate string) error {
-	var deadlineValue interface{}
-	if deadlineDate == "" || deadlineDate == "null" {
-		deadlineValue = nil
-	} else {
-		deadlineValue = deadlineDate
-	}
-	body := map[string]interface{}{
-		"deadline_date": deadlineValue,
-	}
-	return c.doRestApi(ctx, http.MethodPost, "tasks/"+itemID, body, nil)
 }
 
 type ItemFilterResponse struct {

--- a/lib/item.go
+++ b/lib/item.go
@@ -214,11 +214,17 @@ func (item Item) UpdateParam() interface{} {
 	if item.Priority != 0 {
 		param["priority"] = item.Priority
 	}
-	if item.Due != nil {
+	if item.DateString == "null" || item.DateString == "" {
+		param["due"] = nil
+	} else if item.Due != nil {
 		param["due"] = item.Due
 	}
 	if item.Deadline != nil {
-		param["deadline"] = item.Deadline
+		if item.Deadline.Date == "" {
+			param["deadline"] = nil
+		} else {
+			param["deadline"] = item.Deadline
+		}
 	}
 	if item.Description != "" {
 		param["description"] = item.Description

--- a/lib/sync.go
+++ b/lib/sync.go
@@ -6,12 +6,14 @@ type Store struct {
 	DayOrders          interface{}   `json:"day_orders"`
 	DayOrdersTimestamp string        `json:"day_orders_timestamp"`
 	Filters            []struct {
-		Color     string `json:"color"`
-		ID        string `json:"id"`
-		IsDeleted bool   `json:"is_deleted"`
-		ItemOrder int    `json:"item_order"`
-		Name      string `json:"name"`
-		Query     string `json:"query"`
+		ID        string `json:"id"`        // The ID of the filter.
+		Name      string `json:"name"`      // The name of the filter.
+		Query     string `json:"query"`     // The query to search for. Examples of searches can be found in the Todoist help page.
+		Color     string `json:"color"`    // The color of the filter icon. Refer to the name column in the Colors guide for more info.
+		ItemOrder int    `json:"item_order"`     // Filter's order in the filter list (where the smallest value should place the filter at the top).
+		IsDeleted bool   `json:"is_deleted"`    // Whether the filter is marked as deleted (a true or false value).
+		IsFavorite bool  `json:"is_favorite"`   // Whether the filter is a favorite (a true or false value).
+		IsFrozen  bool   `json:"is_frozen"`     // Filters from a canceled subscription cannot be changed. This is a read-only attribute (a true or false value).
 	} `json:"filters"`
 	FullSync          bool   `json:"full_sync"`
 	Items             Items  `json:"items"`

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -142,10 +142,10 @@ func (c *Client) doRestApi(ctx context.Context, method string, uri string, body 
 type ExecResult struct {
 	SyncToken     string                 `json:"sync_token"`
 	SyncStatus    map[string]interface{} `json:"sync_status"`
-	TempIdMapping map[string]string      `json:"temp_id_mapping"`
+	TempIdMapping interface{}            `json:"temp_id_mapping"`
 }
 
-func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) (ExecResult, error) {
+func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 	var r ExecResult
 	params := commands.UrlValues()
 	if c.Store != nil && c.Store.SyncToken != "" {
@@ -155,7 +155,7 @@ func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) 
 	}
 
 	if err := c.doApi(ctx, http.MethodPost, "sync", params, &r); err != nil {
-		return r, err
+		return err
 	}
 
 	for _, command := range commands {
@@ -165,16 +165,11 @@ func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) 
 		}
 
 		if status != "ok" {
-			return r, fmt.Errorf("command %s failed: %v", command.Type, status)
+			return fmt.Errorf("command %s failed: %v", command.Type, status)
 		}
 	}
 
-	return r, nil
-}
-
-func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
-	_, err := c.execCommandsWithResult(ctx, commands)
-	return err
+	return nil
 }
 
 func (c *Client) QuickCommand(ctx context.Context, text string) error {

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -142,10 +142,10 @@ func (c *Client) doRestApi(ctx context.Context, method string, uri string, body 
 type ExecResult struct {
 	SyncToken     string                 `json:"sync_token"`
 	SyncStatus    map[string]interface{} `json:"sync_status"`
-	TempIdMapping interface{}            `json:"temp_id_mapping"`
+	TempIdMapping map[string]string      `json:"temp_id_mapping"`
 }
 
-func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
+func (c *Client) execCommandsWithResult(ctx context.Context, commands Commands) (ExecResult, error) {
 	var r ExecResult
 	params := commands.UrlValues()
 	if c.Store != nil && c.Store.SyncToken != "" {
@@ -155,7 +155,7 @@ func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 	}
 
 	if err := c.doApi(ctx, http.MethodPost, "sync", params, &r); err != nil {
-		return err
+		return r, err
 	}
 
 	for _, command := range commands {
@@ -165,11 +165,16 @@ func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
 		}
 
 		if status != "ok" {
-			return fmt.Errorf("command %s failed: %v", command.Type, status)
+			return r, fmt.Errorf("command %s failed: %v", command.Type, status)
 		}
 	}
 
-	return nil
+	return r, nil
+}
+
+func (c *Client) ExecCommands(ctx context.Context, commands Commands) error {
+	_, err := c.execCommandsWithResult(ctx, commands)
+	return err
 }
 
 func (c *Client) QuickCommand(ctx context.Context, text string) error {

--- a/modify.go
+++ b/modify.go
@@ -78,12 +78,5 @@ func Modify(c *cli.Context) error {
 		}
 	}
 
-	if c.IsSet("deadline") {
-		deadlineDate := c.String("deadline")
-		if err := client.UpdateItemDeadline(context.Background(), item_id, deadlineDate); err != nil {
-			return fmt.Errorf("failed to update deadline for task %s: %w", item_id, err)
-		}
-	}
-
 	return Sync(c)
 }

--- a/modify.go
+++ b/modify.go
@@ -78,5 +78,12 @@ func Modify(c *cli.Context) error {
 		}
 	}
 
+	if c.IsSet("deadline") {
+		deadlineDate := c.String("deadline")
+		if err := client.UpdateItemDeadline(context.Background(), item_id, deadlineDate); err != nil {
+			return fmt.Errorf("failed to update deadline for task %s: %w", item_id, err)
+		}
+	}
+
 	return Sync(c)
 }

--- a/modify.go
+++ b/modify.go
@@ -41,11 +41,7 @@ func Modify(c *cli.Context) error {
 
 	if c.IsSet("deadline") {
 		deadlineDate := c.String("deadline")
-		if deadlineDate == "" || deadlineDate == "null" {
-			item.Deadline = &todoist.Deadline{Date: ""}
-		} else {
-			item.Deadline = &todoist.Deadline{Date: deadlineDate}
-		}
+		item.Deadline = &todoist.Deadline{Date: deadlineDate}
 	}
 
 	projectID := c.String("project-id")

--- a/modify.go
+++ b/modify.go
@@ -37,11 +37,23 @@ func Modify(c *cli.Context) error {
 		item.LabelNames = names
 	}
 
-	item.Due = &todoist.Due{String: c.String("date")}
+	if c.IsSet("date") {
+		dateValue := c.String("date")
+		item.DateString = dateValue
+		if dateValue == "null" {
+			item.Due = nil
+		} else {
+			item.Due = &todoist.Due{String: dateValue}
+		}
+	}
 
 	if c.IsSet("deadline") {
 		deadlineDate := c.String("deadline")
-		item.Deadline = &todoist.Deadline{Date: deadlineDate}
+		if deadlineDate == "null" {
+			item.Deadline = &todoist.Deadline{Date: ""}
+		} else {
+			item.Deadline = &todoist.Deadline{Date: deadlineDate}
+		}
 	}
 
 	projectID := c.String("project-id")


### PR DESCRIPTION
## Summary

Completes the deadline feature by properly handling field clearing.

## Changes

- **lib/item.go**: `UpdateParam()` now correctly clears deadline/due fields when set to null/empty
- **modify.go**: Deadline clearing handler checks for null string before creating Deadline struct
- **lib/sync.go**: Updated Filter struct with complete field documentation (from #327)

## Test Plan

- [x] Build succeeds: `make build`
- [x] Tests pass: `make test`
- [x] Manual test: `todoist modify <id> --deadline null` clears deadline
- [ ] Manual test: `todoist modify <id> --date null` clears due date

_(generated by Claude)_