### PR TITLE
Fix modify command silently resetting priority when -p not specified

### DIFF
--- a/lib/item_test.go
+++ b/lib/item_test.go
@@ -58,6 +58,30 @@ func TestItem_MoveToSectionParam(t *testing.T) {
 	}
 }
 
+func TestItem_UpdateParam_PriorityPreserved(t *testing.T) {
+	item := Item{
+		BaseItem: BaseItem{HaveID: HaveID{ID: "item-1"}},
+		Priority: 3,
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	if param["priority"] != 3 {
+		t.Errorf("expected priority 3 to be included, got %v", param["priority"])
+	}
+}
+
+func TestItem_UpdateParam_ZeroPriorityOmitted(t *testing.T) {
+	item := Item{
+		BaseItem: BaseItem{HaveID: HaveID{ID: "item-1"}},
+		Priority: 0,
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	if _, ok := param["priority"]; ok {
+		t.Errorf("expected priority to be absent when zero, got %v", param["priority"])
+	}
+}
+
 func TestItem_LabelsString(t *testing.T) {
 	item1 := Item{
 		LabelNames: []string{"important", "work", "unknown_label"},

--- a/modify.go
+++ b/modify.go
@@ -25,9 +25,15 @@ func Modify(c *cli.Context) error {
 	if item == nil {
 		return IdNotFound
 	}
-	item.Content = c.String("content")
-	item.Description = c.String("description")
-	item.Priority = priorityMapping[c.Int("priority")]
+	if c.IsSet("content") {
+		item.Content = c.String("content")
+	}
+	if c.IsSet("description") {
+		item.Description = c.String("description")
+	}
+	if c.IsSet("priority") {
+		item.Priority = priorityMapping[c.Int("priority")]
+	}
 	if labelNames := c.String("label-names"); labelNames != "" {
 		stringNames := strings.Split(labelNames, ",")
 		names := []string{}

--- a/modify_test.go
+++ b/modify_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	todoist "github.com/sachaos/todoist/lib"
+)
+
+func TestModify_NoArgs(t *testing.T) {
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = testStore()
+
+	ctx := newTestContext(client, []string{})
+
+	err := Modify(ctx)
+	if err == nil {
+		t.Error("expected error for no args, got nil")
+	}
+}
+
+func TestModify_NotFound(t *testing.T) {
+	client := todoist.NewClient(&todoist.Config{})
+	client.Store = testStore()
+
+	ctx := newTestContext(client, []string{"nonexistent-id"})
+
+	err := Modify(ctx)
+	if !errors.Is(err, IdNotFound) {
+		t.Errorf("expected IdNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `todoist modify <id> -d tomorrow` would silently downgrade any task's priority to p4, even when `-p` was not specified
- Root cause: `priorityFlag` has `Value: 4` as its default, so `c.Int("priority")` always returns 4 → `priorityMapping[4] = 1` (API priority 1 = p4/lowest), which is non-zero and always included in the API call
- Fix: guard `priority`, `content`, and `description` assignments with `c.IsSet()`, consistent with the existing pattern used by `--date` and `--deadline`

## Test plan

- [ ] `TestModify_NoArgs` — zero-args guard returns error
- [ ] `TestModify_NotFound` — ID not found returns `IdNotFound`
- [ ] `TestItem_UpdateParam_PriorityPreserved` — non-zero priority is included in update params
- [ ] `TestItem_UpdateParam_ZeroPriorityOmitted` — zero priority is omitted from update params

Fixes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)