### PR TITLE
Add version subcommand

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - arm
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
 
 archives:
   - id: replace

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func GetClient(c *cli.Context) *todoist.Client {
 // isHelpCommand returns true if the given arguments represent a help invocation
 // that should skip authentication and config setup.
 func isHelpCommand(cliArgs []string, osArgs []string) bool {
-	if len(cliArgs) == 0 || cliArgs[0] == "help" || cliArgs[0] == "h" {
+	if len(cliArgs) == 0 || cliArgs[0] == "help" || cliArgs[0] == "h" || cliArgs[0] == "version" {
 		return true
 	}
 	for _, a := range osArgs {
@@ -524,6 +524,12 @@ func main() {
 			Usage:     "Quick add a task",
 			Action:    Quick,
 			ArgsUsage: "<Item content>",
+		},
+		{
+			Name:      "version",
+			Usage:     "Show version information",
+			Action:    Version,
+			ArgsUsage: " ",
 		},
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	commit string
+	date   string
+)
+
+func Version(c *cli.Context) error {
+	if version == "" {
+		fmt.Println("todoist (dev build)")
+		return nil
+	}
+	if commit != "" && date != "" {
+		fmt.Printf("todoist %s (commit %s, built %s)\n", version, commit, date)
+		return nil
+	}
+	fmt.Printf("todoist %s\n", version)
+	return nil
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	todoist "github.com/sachaos/todoist/lib"
+)
+
+func TestVersion_DevBuild(t *testing.T) {
+	orig := version
+	version = ""
+	defer func() { version = orig }()
+
+	ctx := newTestContext(todoist.NewClient(&todoist.Config{}), []string{})
+	if err := Version(ctx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestVersion_WithCommitAndDate(t *testing.T) {
+	origVersion, origCommit, origDate := version, commit, date
+	version = "0.21.0"
+	commit = "abc1234"
+	date = "2026-05-04"
+	defer func() {
+		version = origVersion
+		commit = origCommit
+		date = origDate
+	}()
+
+	ctx := newTestContext(todoist.NewClient(&todoist.Config{}), []string{})
+	if err := Version(ctx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestVersion_VersionOnly(t *testing.T) {
+	origVersion, origCommit, origDate := version, commit, date
+	version = "0.21.0"
+	commit = ""
+	date = ""
+	defer func() {
+		version = origVersion
+		commit = origCommit
+		date = origDate
+	}()
+
+	ctx := newTestContext(todoist.NewClient(&todoist.Config{}), []string{})
+	if err := Version(ctx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #336

## Summary

- **`version.go`**: New `Version` handler and `commit`/`date` package-level vars. Prints `todoist <version> (commit <sha>, built <date>)` for release builds, `todoist (dev build)` when no ldflags are injected.
- **`main.go`**: Extends `isHelpCommand` to skip auth/config setup for the `version` subcommand (it's purely local); registers the command.
- **`.goreleaser.yml`**: Extends ldflags to inject `commit` and `date` alongside `version` for release builds only.
- **`version_test.go`**: Tests all three output branches (dev build, version+commit+date, version-only).

## Design notes

- No aliases — avoids conceptual collision with the existing `-v`/`--version` global flag (which urfave/cli auto-handles).
- `isHelpCommand` extended rather than creating a separate skip-list — keeps the auth-bypass logic in one place.
- ldflags injected only in `.goreleaser.yml`; local `make build`/`make install` intentionally produce `(dev build)`.

## Test plan

- [ ] `make build && make test` — passes
- [ ] `./todoist version` (local dev build) → `todoist (dev build)`
- [ ] `todoist version --help` → shows usage without prompting for API token
- [ ] Release build (or manual ldflags): `go build -ldflags "-X main.version=0.21.0 -X main.commit=abc1234 -X main.date=2026-05-04" && ./todoist version` → `todoist 0.21.0 (commit abc1234, built 2026-05-04)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)