### PR TITLE
Fix modify --content "" and --description "" silently dropping clear intent

### DIFF
--- a/lib/item.go
+++ b/lib/item.go
@@ -70,28 +70,36 @@ type Item struct {
 	HaveParentID
 	HaveIndent
 	HaveSectionID
-	ChildItem      *Item       `json:"-"`
-	BrotherItem    *Item       `json:"-"`
-	Description    string      `json:"description"`
-	AllDay         bool        `json:"all_day"`
-	AssignedByUID  string      `json:"assigned_by_uid"`
-	Checked        bool        `json:"checked"`
-	Collapsed      bool        `json:"collapsed"`
-	DateAdded      string      `json:"added_at"`
-	DateLang       string      `json:"date_lang"`
-	DateString     string      `json:"date_string"`
-	DayOrder       int         `json:"day_order"`
-	Due            *Due        `json:"due"`
-	Deadline       *Deadline   `json:"deadline"`
-	HasMoreNotes   bool        `json:"has_more_notes"`
-	IsArchived     int         `json:"is_archived"`
-	IsDeleted      bool        `json:"is_deleted"`
-	ItemOrder      int         `json:"item_order"`
-	LabelNames     []string    `json:"labels"`
-	Priority       int         `json:"priority"`
-	AutoReminder   bool        `json:"auto_reminder"`
-	ResponsibleUID interface{} `json:"responsible_uid"`
-	SyncID         interface{} `json:"sync_id"`
+	ChildItem   *Item `json:"-"`
+	BrotherItem *Item `json:"-"`
+	// ClearContent signals UpdateParam to send content="" to the API,
+	// allowing the user to explicitly clear a task's content. Set by
+	// modify.go when --content is explicitly passed as an empty string.
+	ClearContent bool `json:"-"`
+	// ClearDescription signals UpdateParam to send description="" to the API,
+	// allowing the user to explicitly clear a task's description. Set by
+	// modify.go when --description is explicitly passed as an empty string.
+	ClearDescription bool        `json:"-"`
+	Description      string      `json:"description"`
+	AllDay           bool        `json:"all_day"`
+	AssignedByUID    string      `json:"assigned_by_uid"`
+	Checked          bool        `json:"checked"`
+	Collapsed        bool        `json:"collapsed"`
+	DateAdded        string      `json:"added_at"`
+	DateLang         string      `json:"date_lang"`
+	DateString       string      `json:"date_string"`
+	DayOrder         int         `json:"day_order"`
+	Due              *Due        `json:"due"`
+	Deadline         *Deadline   `json:"deadline"`
+	HasMoreNotes     bool        `json:"has_more_notes"`
+	IsArchived       int         `json:"is_archived"`
+	IsDeleted        bool        `json:"is_deleted"`
+	ItemOrder        int         `json:"item_order"`
+	LabelNames       []string    `json:"labels"`
+	Priority         int         `json:"priority"`
+	AutoReminder     bool        `json:"auto_reminder"`
+	ResponsibleUID   interface{} `json:"responsible_uid"`
+	SyncID           interface{} `json:"sync_id"`
 }
 
 type Items []Item
@@ -198,7 +206,7 @@ func (item Item) UpdateParam() interface{} {
 	if item.ID != "" {
 		param["id"] = item.ID
 	}
-	if item.Content != "" {
+	if item.Content != "" || item.ClearContent {
 		param["content"] = item.Content
 	}
 	if item.DateString != "" {
@@ -226,7 +234,7 @@ func (item Item) UpdateParam() interface{} {
 			param["deadline"] = item.Deadline
 		}
 	}
-	if item.Description != "" {
+	if item.Description != "" || item.ClearDescription {
 		param["description"] = item.Description
 	}
 	return param

--- a/lib/item_test.go
+++ b/lib/item_test.go
@@ -82,6 +82,62 @@ func TestItem_UpdateParam_ZeroPriorityOmitted(t *testing.T) {
 	}
 }
 
+func TestItem_UpdateParam_ClearContent(t *testing.T) {
+	item := Item{
+		BaseItem:     BaseItem{HaveID: HaveID{ID: "item-1"}, Content: ""},
+		ClearContent: true,
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	v, ok := param["content"]
+	if !ok {
+		t.Fatal("expected content to be present when ClearContent is true")
+	}
+	if v != "" {
+		t.Errorf("expected empty content, got %v", v)
+	}
+}
+
+func TestItem_UpdateParam_EmptyContentOmittedWithoutClearFlag(t *testing.T) {
+	item := Item{
+		BaseItem: BaseItem{HaveID: HaveID{ID: "item-1"}, Content: ""},
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	if _, ok := param["content"]; ok {
+		t.Error("expected content to be absent when empty and ClearContent is false")
+	}
+}
+
+func TestItem_UpdateParam_ClearDescription(t *testing.T) {
+	item := Item{
+		BaseItem:         BaseItem{HaveID: HaveID{ID: "item-1"}},
+		Description:      "",
+		ClearDescription: true,
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	v, ok := param["description"]
+	if !ok {
+		t.Fatal("expected description to be present when ClearDescription is true")
+	}
+	if v != "" {
+		t.Errorf("expected empty description, got %v", v)
+	}
+}
+
+func TestItem_UpdateParam_EmptyDescriptionOmittedWithoutClearFlag(t *testing.T) {
+	item := Item{
+		BaseItem:    BaseItem{HaveID: HaveID{ID: "item-1"}},
+		Description: "",
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	if _, ok := param["description"]; ok {
+		t.Error("expected description to be absent when empty and ClearDescription is false")
+	}
+}
+
 func TestItem_LabelsString(t *testing.T) {
 	item1 := Item{
 		LabelNames: []string{"important", "work", "unknown_label"},

--- a/modify.go
+++ b/modify.go
@@ -27,9 +27,11 @@ func Modify(c *cli.Context) error {
 	}
 	if c.IsSet("content") {
 		item.Content = c.String("content")
+		item.ClearContent = item.Content == ""
 	}
 	if c.IsSet("description") {
 		item.Description = c.String("description")
+		item.ClearDescription = item.Description == ""
 	}
 	if c.IsSet("priority") {
 		item.Priority = priorityMapping[c.Int("priority")]


### PR DESCRIPTION
Fixes #335.

`UpdateParam` in `lib/item.go` skipped `content` and `description` whenever their value was the empty string, so passing `--content ""` or `--description ""` to `todoist modify` silently did nothing. This adds `ClearContent`/`ClearDescription` sentinels (mirroring the `Deadline.Date == ""` pattern at line 222) that `modify.go` sets when the user explicitly passes an empty value via `c.IsSet`, allowing the API to receive the clearing intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)