### PR TITLE
Fix modify --label-names "" silently dropping clear intent

### DIFF
--- a/lib/item.go
+++ b/lib/item.go
@@ -70,28 +70,32 @@ type Item struct {
 	HaveParentID
 	HaveIndent
 	HaveSectionID
-	ChildItem      *Item       `json:"-"`
-	BrotherItem    *Item       `json:"-"`
-	Description    string      `json:"description"`
-	AllDay         bool        `json:"all_day"`
-	AssignedByUID  string      `json:"assigned_by_uid"`
-	Checked        bool        `json:"checked"`
-	Collapsed      bool        `json:"collapsed"`
-	DateAdded      string      `json:"added_at"`
-	DateLang       string      `json:"date_lang"`
-	DateString     string      `json:"date_string"`
-	DayOrder       int         `json:"day_order"`
-	Due            *Due        `json:"due"`
-	Deadline       *Deadline   `json:"deadline"`
-	HasMoreNotes   bool        `json:"has_more_notes"`
-	IsArchived     int         `json:"is_archived"`
-	IsDeleted      bool        `json:"is_deleted"`
-	ItemOrder      int         `json:"item_order"`
-	LabelNames     []string    `json:"labels"`
-	Priority       int         `json:"priority"`
-	AutoReminder   bool        `json:"auto_reminder"`
-	ResponsibleUID interface{} `json:"responsible_uid"`
-	SyncID         interface{} `json:"sync_id"`
+	ChildItem   *Item `json:"-"`
+	BrotherItem *Item `json:"-"`
+	// ClearLabelNames signals UpdateParam to send labels=[] to the API,
+	// allowing the user to explicitly clear all labels on a task. Set by
+	// modify.go when --label-names is explicitly passed as an empty string.
+	ClearLabelNames bool        `json:"-"`
+	Description     string      `json:"description"`
+	AllDay          bool        `json:"all_day"`
+	AssignedByUID   string      `json:"assigned_by_uid"`
+	Checked         bool        `json:"checked"`
+	Collapsed       bool        `json:"collapsed"`
+	DateAdded       string      `json:"added_at"`
+	DateLang        string      `json:"date_lang"`
+	DateString      string      `json:"date_string"`
+	DayOrder        int         `json:"day_order"`
+	Due             *Due        `json:"due"`
+	Deadline        *Deadline   `json:"deadline"`
+	HasMoreNotes    bool        `json:"has_more_notes"`
+	IsArchived      int         `json:"is_archived"`
+	IsDeleted       bool        `json:"is_deleted"`
+	ItemOrder       int         `json:"item_order"`
+	LabelNames      []string    `json:"labels"`
+	Priority        int         `json:"priority"`
+	AutoReminder    bool        `json:"auto_reminder"`
+	ResponsibleUID  interface{} `json:"responsible_uid"`
+	SyncID          interface{} `json:"sync_id"`
 }
 
 type Items []Item
@@ -208,7 +212,7 @@ func (item Item) UpdateParam() interface{} {
 	if item.DateString == "null" {
 		param["date_string"] = ""
 	}
-	if len(item.LabelNames) != 0 {
+	if len(item.LabelNames) != 0 || item.ClearLabelNames {
 		param["labels"] = item.LabelNames
 	}
 	if item.Priority != 0 {

--- a/lib/item_test.go
+++ b/lib/item_test.go
@@ -82,6 +82,39 @@ func TestItem_UpdateParam_ZeroPriorityOmitted(t *testing.T) {
 	}
 }
 
+func TestItem_UpdateParam_ClearLabelNames(t *testing.T) {
+	item := Item{
+		BaseItem:        BaseItem{HaveID: HaveID{ID: "item-1"}},
+		LabelNames:      []string{},
+		ClearLabelNames: true,
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	v, ok := param["labels"]
+	if !ok {
+		t.Fatal("expected labels to be present when ClearLabelNames is true")
+	}
+	labels, ok := v.([]string)
+	if !ok {
+		t.Fatalf("expected labels to be []string, got %T", v)
+	}
+	if len(labels) != 0 {
+		t.Errorf("expected empty labels, got %v", labels)
+	}
+}
+
+func TestItem_UpdateParam_EmptyLabelNamesOmittedWithoutClearFlag(t *testing.T) {
+	item := Item{
+		BaseItem:   BaseItem{HaveID: HaveID{ID: "item-1"}},
+		LabelNames: []string{},
+	}
+	param := item.UpdateParam().(map[string]interface{})
+
+	if _, ok := param["labels"]; ok {
+		t.Error("expected labels to be absent when empty and ClearLabelNames is false")
+	}
+}
+
 func TestItem_LabelsString(t *testing.T) {
 	item1 := Item{
 		LabelNames: []string{"important", "work", "unknown_label"},

--- a/modify.go
+++ b/modify.go
@@ -34,13 +34,19 @@ func Modify(c *cli.Context) error {
 	if c.IsSet("priority") {
 		item.Priority = priorityMapping[c.Int("priority")]
 	}
-	if labelNames := c.String("label-names"); labelNames != "" {
-		stringNames := strings.Split(labelNames, ",")
-		names := []string{}
-		for _, stringName := range stringNames {
-			names = append(names, strings.TrimSpace(stringName))
+	if c.IsSet("label-names") {
+		labelNames := c.String("label-names")
+		if labelNames == "" {
+			item.LabelNames = []string{}
+			item.ClearLabelNames = true
+		} else {
+			stringNames := strings.Split(labelNames, ",")
+			names := []string{}
+			for _, stringName := range stringNames {
+				names = append(names, strings.TrimSpace(stringName))
+			}
+			item.LabelNames = names
 		}
-		item.LabelNames = names
 	}
 
 	if c.IsSet("date") {


### PR DESCRIPTION
Fixes #334.

The `--label-names` block in `modify.go` used `if labelNames != ""` instead of `c.IsSet("label-names")`, so passing `--label-names ""` to clear all labels was silently ignored. Even after switching to `c.IsSet`, `UpdateParam` filtered out empty label slices via `len(item.LabelNames) != 0`, so this adds a `ClearLabelNames` sentinel mirroring the `Deadline.Date == ""` pattern at lib/item.go:222 (and the `ClearContent`/`ClearDescription` sentinels from #338) so the API receives the clearing intent.