### PR TITLE
Add support to match style of a project name starting with a #

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: prepare
 
 .PHONY: test
 test: prepare
-	go test -v
+	go test -v ./...
 
 .PHONY: prepare
 prepare: filter_parser.go

--- a/lib/project.go
+++ b/lib/project.go
@@ -32,6 +32,7 @@ func (a Projects) Less(i, j int) bool { return a[i].ID < a[j].ID }
 func (a Projects) At(i int) IDCarrier { return a[i] }
 
 func (a Projects) GetIDByName(name string) string {
+	name = strings.TrimPrefix(name, "#")
 	for _, pjt := range a {
 		if pjt.Name == name {
 			return pjt.GetID()

--- a/lib/project_test.go
+++ b/lib/project_test.go
@@ -1,0 +1,39 @@
+package todoist
+
+import (
+	"testing"
+)
+
+func TestProjects_GetIDByName(t *testing.T) {
+	projects := Projects{
+		Project{HaveID: HaveID{ID: "1"}, Name: "Inbox"},
+		Project{HaveID: HaveID{ID: "2"}, Name: "Packing"},
+		Project{HaveID: HaveID{ID: "3"}, Name: "Work"},
+	}
+
+	// Bare name lookup works
+	if id := projects.GetIDByName("Packing"); id != "2" {
+		t.Errorf("expected '2', got '%s'", id)
+	}
+
+	// # prefix is stripped before matching, matching ProjectFormat display output
+	if id := projects.GetIDByName("#Packing"); id != "2" {
+		t.Errorf("expected '2', got '%s'", id)
+	}
+
+	// Not found returns empty string
+	if id := projects.GetIDByName("Nonexistent"); id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+
+	// # prefix alone (no name) returns empty string
+	if id := projects.GetIDByName("#"); id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+
+	// Empty projects returns empty string
+	empty := Projects{}
+	if id := empty.GetIDByName("Packing"); id != "" {
+		t.Errorf("expected '', got '%s'", id)
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/sachaos/todoist/issues/343

This is a fix to add support for Project names to start with a `#`.