### PR TITLE
docs: update Homebrew install instructions to use homebrew-core (todoist-cli-go)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ It has following parameters:
 
 ## Install
 
-### Homebrew (Mac OS / Linux)
+### Homebrew (Mac OS)
 
 ```
 $ brew install todoist-cli-go

--- a/README.md
+++ b/README.md
@@ -118,13 +118,21 @@ It has following parameters:
 
 ### Homebrew (Mac OS)
 
+From homebrew-core:
+
 ```
 $ brew install todoist-cli-go
 ```
 
+Or from this project's tap:
+
+```
+$ brew install sachaos/todoist/todoist
+```
+
 > [!IMPORTANT]
-> The formula name is **`todoist-cli-go`**, not `todoist-cli`.
-> `todoist-cli` is a separate formula for the [official Doist CLI](https://github.com/Doist/todoist-cli), which is a different tool. This formula was previously named `todoist-cli` but was renamed to make room for the official one. The `sachaos/todoist` tap is no longer required.
+> The homebrew-core formula name is **`todoist-cli-go`**, not `todoist-cli`.
+> `todoist-cli` is a separate formula for the [official Doist CLI](https://github.com/Doist/todoist-cli), which is a different tool. This formula was previously named `todoist-cli` but was renamed to make room for the official one.
 
 ### AUR
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ It has following parameters:
 $ brew install todoist-cli-go
 ```
 
-The formula was previously named `todoist-cli` but was renamed to `todoist-cli-go` to free up the `todoist-cli` name for the official Doist CLI. The `sachaos/todoist` tap is no longer required.
+> [!IMPORTANT]
+> The formula name is **`todoist-cli-go`**, not `todoist-cli`.
+> `todoist-cli` is a separate formula for the [official Doist CLI](https://github.com/Doist/todoist-cli), which is a different tool. This formula was previously named `todoist-cli` but was renamed to make room for the official one. The `sachaos/todoist` tap is no longer required.
 
 ### AUR
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,13 @@ It has following parameters:
 
 ## Install
 
-### Homebrew (Mac OS)
+### Homebrew (Mac OS / Linux)
 
 ```
-$ brew install sachaos/todoist/todoist
+$ brew install todoist-cli-go
 ```
+
+The formula was previously named `todoist-cli` but was renamed to `todoist-cli-go` to free up the `todoist-cli` name for the official Doist CLI. The `sachaos/todoist` tap is no longer required.
 
 ### AUR
 


### PR DESCRIPTION
## Summary

Update the README's Homebrew install instructions to use the homebrew-core formula:

```sh
$ brew install todoist-cli-go
```

Also add a callout warning users not to confuse this with `todoist-cli`, which is now a separate formula for the official Doist CLI.

## Why

Homebrew/homebrew-core#283528 landed this tool in homebrew-core, so the `sachaos/todoist` tap is no longer needed.

Note that the formula is named **`todoist-cli-go`**, not `todoist-cli`. The `todoist-cli` name was handed over to the [official Doist CLI](https://github.com/Doist/todoist-cli), and this formula was renamed accordingly. The README now explains this so users don't install the wrong package.

## Review points

- Is `todoist-cli-go` the right name to advertise?
- Wording of the rename / disambiguation callout

## Test plan

```sh
$ brew install todoist-cli-go
$ todoist --version
```

(Until the homebrew API JSON catches up, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install todoist-cli-go` works as a fallback.)

_(generated by Claude)_
