### PR TITLE
feat: add schema_version to local cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,12 @@ Use the **REST API** (`doRestApi`) when:
 
 **Do NOT call `Sync(c)`** when the command operates on completed tasks or resources that were never in the cache. The cache stays internally consistent because it never held those items. Examples: `reopen`. Add a comment in the handler explaining the omission so future maintainers don't add it back by mistake.
 
+### Cache schema version
+
+`lib/sync.go` defines `CurrentSchemaVersion`. **Bump this constant whenever the `Store` struct changes in a way that would make an existing cache incompatible** — adding a field with a new type, renaming a field, changing a field's JSON tag, or removing a field that the app relies on. Do NOT bump it for purely additive changes where the old cache would still work correctly (e.g. adding a nullable field that defaults to zero/nil).
+
+When `ReadCache` sees a version mismatch it resets `SyncToken = "*"`, forcing a full resync on the next run. This is intentional — the user gets a clean cache rather than corrupted data.
+
 ### doRestApi behavior
 
 `doRestApi` in `lib/todoist.go` treats both **200 OK** and **204 No Content** as success. When adding a new REST-based lib function, always check the OpenAPI spec (at `todoist-openapi.json` in the repo root) to confirm which status code the endpoint returns — don't assume 200.

--- a/cache.go
+++ b/cache.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sachaos/todoist/lib"
 )
 
+const currentSchemaVersion = 1
+
 func LoadCache(filename string, s *todoist.Store) error {
 	err := ReadCache(filename, s)
 	if err != nil {
@@ -21,12 +23,27 @@ func LoadCache(filename string, s *todoist.Store) error {
 }
 
 func ReadCache(filename string, s *todoist.Store) error {
-	jsonString, err := ioutil.ReadFile(filename)
+	jsonBytes, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return CommandFailed
 	}
-	err = json.Unmarshal(jsonString, &s)
-	if err != nil {
+
+	// Two-pass: check schema version before full unmarshal so that a
+	// schema change never leaves the cache in a broken state.
+	var meta struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	json.Unmarshal(jsonBytes, &meta) // error ignored: missing field yields 0
+
+	if meta.SchemaVersion != currentSchemaVersion {
+		// Old or mismatched cache: force a full resync on next sync call.
+		s.SyncToken = "*"
+		s.SchemaVersion = currentSchemaVersion
+		_ = WriteCache(filename, s)
+		return nil
+	}
+
+	if err := json.Unmarshal(jsonBytes, s); err != nil {
 		return CommandFailed
 	}
 	s.ConstructItemTree()

--- a/cache.go
+++ b/cache.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sachaos/todoist/lib"
 )
 
-const currentSchemaVersion = 1
+const currentSchemaVersion = todoist.CurrentSchemaVersion
 
 func LoadCache(filename string, s *todoist.Store) error {
 	err := ReadCache(filename, s)
@@ -39,7 +39,9 @@ func ReadCache(filename string, s *todoist.Store) error {
 		// Old or mismatched cache: force a full resync on next sync call.
 		s.SyncToken = "*"
 		s.SchemaVersion = currentSchemaVersion
-		_ = WriteCache(filename, s)
+		if err := WriteCache(filename, s); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/cache.go
+++ b/cache.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/sachaos/todoist/lib"
@@ -23,7 +22,7 @@ func LoadCache(filename string, s *todoist.Store) error {
 }
 
 func ReadCache(filename string, s *todoist.Store) error {
-	jsonBytes, err := ioutil.ReadFile(filename)
+	jsonBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return CommandFailed
 	}
@@ -61,7 +60,7 @@ func WriteCache(filename string, s *todoist.Store) error {
 	if err != nil {
 		return err
 	}
-	err2 := ioutil.WriteFile(filename, buf, os.ModePerm)
+	err2 := os.WriteFile(filename, buf, os.ModePerm)
 	if err2 != nil {
 		return errors.New("Couldn't write to the cache file")
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	todoist "github.com/sachaos/todoist/lib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempCache(t *testing.T, content map[string]interface{}) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "cache-*.json")
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, json.NewEncoder(f).Encode(content))
+	return f.Name()
+}
+
+func TestReadCache_FileNotFound(t *testing.T) {
+	var s todoist.Store
+	err := ReadCache("/nonexistent/path/cache.json", &s)
+	assert.Error(t, err)
+}
+
+func TestReadCache_OldCache_NoSchemaVersion(t *testing.T) {
+	// Old caches have no schema_version field; json.Unmarshal sets missing
+	// int fields to 0, which != currentSchemaVersion, so SyncToken must be
+	// reset. This test verifies both the Go behavior and the reset logic.
+	path := writeTempCache(t, map[string]interface{}{
+		"sync_token": "abc123",
+		"items":      []interface{}{},
+	})
+	var s todoist.Store
+	err := ReadCache(path, &s)
+	assert.NoError(t, err)
+	assert.Equal(t, "*", s.SyncToken)
+	assert.Equal(t, currentSchemaVersion, s.SchemaVersion)
+}
+
+func TestReadCache_WrongSchemaVersion(t *testing.T) {
+	path := writeTempCache(t, map[string]interface{}{
+		"sync_token":     "abc123",
+		"schema_version": 99,
+		"items":          []interface{}{},
+	})
+	var s todoist.Store
+	err := ReadCache(path, &s)
+	assert.NoError(t, err)
+	assert.Equal(t, "*", s.SyncToken)
+	assert.Equal(t, currentSchemaVersion, s.SchemaVersion)
+}
+
+func TestReadCache_CorrectSchemaVersion_PreservesSyncToken(t *testing.T) {
+	path := writeTempCache(t, map[string]interface{}{
+		"sync_token":     "mytoken",
+		"schema_version": 1,
+		"items":          []interface{}{},
+		"projects":       []interface{}{},
+		"labels":         []interface{}{},
+		"sections":       []interface{}{},
+	})
+	var s todoist.Store
+	err := ReadCache(path, &s)
+	assert.NoError(t, err)
+	assert.Equal(t, "mytoken", s.SyncToken)
+	assert.Equal(t, 1, s.SchemaVersion)
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -25,6 +25,17 @@ func TestReadCache_FileNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func assertCacheFileSchemaVersion(t *testing.T, path string, want int) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var stored struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	require.NoError(t, json.Unmarshal(data, &stored))
+	assert.Equal(t, want, stored.SchemaVersion, "schema_version in cache file on disk")
+}
+
 func TestReadCache_OldCache_NoSchemaVersion(t *testing.T) {
 	// Old caches have no schema_version field; json.Unmarshal sets missing
 	// int fields to 0, which != currentSchemaVersion, so SyncToken must be
@@ -38,6 +49,7 @@ func TestReadCache_OldCache_NoSchemaVersion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "*", s.SyncToken)
 	assert.Equal(t, currentSchemaVersion, s.SchemaVersion)
+	assertCacheFileSchemaVersion(t, path, currentSchemaVersion)
 }
 
 func TestReadCache_WrongSchemaVersion(t *testing.T) {
@@ -51,6 +63,7 @@ func TestReadCache_WrongSchemaVersion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "*", s.SyncToken)
 	assert.Equal(t, currentSchemaVersion, s.SchemaVersion)
+	assertCacheFileSchemaVersion(t, path, currentSchemaVersion)
 }
 
 func TestReadCache_CorrectSchemaVersion_PreservesSyncToken(t *testing.T) {

--- a/lib/sync.go
+++ b/lib/sync.go
@@ -1,5 +1,7 @@
 package todoist
 
+const CurrentSchemaVersion = 1
+
 type Store struct {
 	CollaboratorStates []interface{} `json:"collaborator_states"`
 	Collaborators      []interface{} `json:"collaborators"`

--- a/lib/sync.go
+++ b/lib/sync.go
@@ -60,6 +60,7 @@ type Store struct {
 		Type         string      `json:"type"`
 	} `json:"reminders"`
 	SyncToken     string              `json:"sync_token"`
+	SchemaVersion int                 `json:"schema_version"`
 	TempIDMapping struct{}            `json:"temp_id_mapping"`
 	User          User                `json:"user"`
 	RootItem      *Item               `json:"-"`

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -189,6 +189,7 @@ func (c *Client) Sync(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	c.Store.SchemaVersion = CurrentSchemaVersion
 	c.Store.ConstructItemTree()
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `SchemaVersion` field to `Store` in `lib/sync.go` with `CurrentSchemaVersion = 1` constant
- `lib/todoist.go`'s `Sync()` now stamps `CurrentSchemaVersion` onto the store after every API sync, so it is always persisted correctly
- `ReadCache` uses a two-pass unmarshal: checks `schema_version` from raw bytes first; on mismatch (including old caches with no field, which unmarshal as 0), resets `SyncToken = "*"` to force a full resync on next sync call
- Replaces deprecated `ioutil` with `os` package in `cache.go`

Closes #342

## Test Plan

- [ ] `make test` passes
- [ ] On first run after upgrade, old cache (no `schema_version`) triggers one full resync, then stabilises
- [ ] Subsequent runs with `schema_version: 1` cache proceed normally without resyncing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)