### PR TITLE
Fix full sync merging into cached store, corrupting item section_id

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -44,6 +44,10 @@ func ReadCache(filename string, s *todoist.Store) error {
 		return nil
 	}
 
+	// Reset before unmarshal: decoding into a populated store merges into
+	// existing slice elements instead of replacing them.
+	*s = todoist.Store{}
+
 	if err := json.Unmarshal(jsonBytes, s); err != nil {
 		return CommandFailed
 	}

--- a/lib/main.go
+++ b/lib/main.go
@@ -12,7 +12,7 @@ var (
 	FindFailed = errors.New("Find Failed")
 )
 
-const (
+var (
 	Server = "https://api.todoist.com/api/v1/"
 )
 

--- a/lib/sync_test.go
+++ b/lib/sync_test.go
@@ -1,0 +1,66 @@
+package todoist
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test: a full sync must fully replace the cached store. Decoding
+// the response into an already-populated store merges each incoming item into
+// whatever cached item previously occupied the same slice index, and a JSON
+// null section_id leaves that unrelated item's stale SectionID in place.
+func TestSyncReplacesCachedStore(t *testing.T) {
+	response := `{
+		"full_sync": true,
+		"sync_token": "token-2",
+		"items": [
+			{"id": "2", "content": "task two", "project_id": "p1", "section_id": null},
+			{"id": "1", "content": "task one", "project_id": "p1", "section_id": "s1"}
+		],
+		"projects": [{"id": "p1", "name": "Project"}],
+		"labels": []
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	origServer := Server
+	Server = server.URL
+	defer func() { Server = origServer }()
+
+	client := NewClient(&Config{AccessToken: "dummy"})
+
+	// Simulate the store loaded from cache.json: same tasks, but ordered
+	// differently than the sync response, with item 1 holding a section.
+	cached := &Store{
+		SyncToken: "token-1",
+		Items: Items{
+			{BaseItem: BaseItem{HaveID: HaveID{ID: "1"}, Content: "task one", HaveProjectID: HaveProjectID{ProjectID: "p1"}}, HaveSectionID: HaveSectionID{SectionID: "s1"}},
+			{BaseItem: BaseItem{HaveID: HaveID{ID: "2"}, Content: "task two", HaveProjectID: HaveProjectID{ProjectID: "p1"}}},
+		},
+		Projects: Projects{
+			{HaveID: HaveID{ID: "p1"}, Name: "Project"},
+		},
+	}
+	cached.ConstructItemTree()
+	client.Store = cached
+
+	err := client.Sync(context.Background())
+	assert.NoError(t, err)
+
+	itemOne := client.Store.FindItem("1")
+	itemTwo := client.Store.FindItem("2")
+	assert.NotNil(t, itemOne)
+	assert.NotNil(t, itemTwo)
+
+	assert.Equal(t, "s1", itemOne.SectionID, "item 1 should keep its section")
+	assert.Equal(t, "", itemTwo.SectionID, "item 2 has a null section_id and must not inherit a stale section from the cache")
+	assert.Equal(t, "token-2", client.Store.SyncToken)
+}

--- a/lib/todoist.go
+++ b/lib/todoist.go
@@ -185,9 +185,18 @@ func (c *Client) QuickCommand(ctx context.Context, text string) error {
 func (c *Client) Sync(ctx context.Context) error {
 	params := url.Values{"sync_token": {"*"}, "resource_types": {"[\"all\"]"}}
 
-	err := c.doApi(ctx, http.MethodPost, "sync", params, &c.Store)
+	// Decode into a fresh store: decoding into the cache-populated store
+	// merges each incoming item into whatever item previously occupied the
+	// same slice index, and null fields (e.g. section_id) keep stale values.
+	store := Store{}
+	err := c.doApi(ctx, http.MethodPost, "sync", params, &store)
 	if err != nil {
 		return err
+	}
+	if c.Store == nil {
+		c.Store = &store
+	} else {
+		*c.Store = store
 	}
 	c.Store.SchemaVersion = CurrentSchemaVersion
 	c.Store.ConstructItemTree()


### PR DESCRIPTION
## What

After a `todoist sync`, items in the local cache could end up pointing at the wrong section — a `section_id` belonging to an unrelated task — and the corruption was persisted into `cache.json`. Fixes #351.

## Why it happened

`Client.Sync` decoded the full-sync response directly into `c.Store`, which is already populated from `cache.json` at startup. Go's `encoding/json` merges into non-empty slices index-by-index instead of replacing them, and JSON `null` is a no-op on non-pointer fields. The API returns items in a different order than the cached slice, so each incoming item was merged over an unrelated cached task — and any task with `"section_id": null` silently kept the stale `SectionID` of whatever task previously occupied its slice index. See #351 for the full analysis and history.

## Changes

- `lib/todoist.go` — `Sync` decodes into a fresh `Store` and swaps it into `c.Store`, so a full sync fully replaces cached state (pointer identity preserved; master's `SchemaVersion` assignment kept).
- `cache.go` — `ReadCache` zeroes the store before unmarshaling, closing the same merge hazard on the cache-reload path.
- `lib/sync_test.go` — regression test: serves a reordered sync payload with a `null` `section_id` over a pre-populated store via `httptest`; it fails with the stale-section symptom against the old code.
- `lib/main.go` — `Server` changed from `const` to `var` so the test can point it at the fake server.

## Notes for reviewers

- Existing `cache.json` files may already contain wrong `section_id` values from past syncs; the first `todoist sync` with this fix rewrites the cache correctly.
- This also lays the right foundation for future incremental sync: decode the delta into fresh memory, then apply deliberately (upsert by ID) rather than letting the JSON decoder improvise an index-based merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
